### PR TITLE
Add seyfert support to shoukaku

### DIFF
--- a/src/connectors/README.md
+++ b/src/connectors/README.md
@@ -21,6 +21,14 @@ const { Shoukaku, Connectors } = require('shoukaku');
 new Shoukaku(new Connectors.OceanicJS(client), servers, options)
 ```
 
+> [Seyfert](https://seyfert-docs.vercel.app/) (0.1.x)
+
+```js
+const { Shoukaku, Connectors } = require('shoukaku');
+new Shoukaku(new Connectors.Seyfert(client), servers, options)
+```
+
+
 > Implement your own 
 
 ## Implementing your own

--- a/src/connectors/libs/Seyfert.ts
+++ b/src/connectors/libs/Seyfert.ts
@@ -1,0 +1,25 @@
+import { Connector } from '../Connector';
+import { NodeOption } from '../../Shoukaku';
+
+export class Seyfert extends Connector {
+    // sendPacket is where your library send packets to Discord Gateway
+    public sendPacket(shardId: number, payload: any, important: boolean): void {
+        return this.client.gateway.send(shardId, payload);
+    }
+    // getId is a getter where the lib stores the client user (the one logged in as a bot) id
+    public getId(): string {
+        return this.client.botId;
+    }
+    // Listen attaches the event listener to the library you are using
+    public listen(nodes: NodeOption[]): void {
+        this.client.events.values.RAW = {
+            data: { name: "raw" },
+            run: (packet: any) => {
+                // Only attach to ready event once, refer to your library for its ready event
+                if (packet.t === "READY") return this.ready(nodes);
+                // Attach to the raw websocket event, this event must be 1:1 on spec with dapi (most libs implement this)
+                return this.raw(packet);
+            }
+        }
+    }
+}

--- a/src/connectors/libs/index.ts
+++ b/src/connectors/libs/index.ts
@@ -1,3 +1,4 @@
 export * from './DiscordJS';
 export * from './Eris';
 export * from './OceanicJS';
+export * from "./Seyfert"


### PR DESCRIPTION
Recently came out a library to interact with the discord API called "seyfert", this library is quite recent, but there is a release that is usable.

The version of seyfert with which this `Connector` was made is the github version.
Or at least that's how it is at the time I made this PR (02-27-2024).

Github version: https://github.com/potoland/potocuit (aka seyfert)
npmjs: https://npmjs.com/package/seyfert

Why? Because the github version has the necessary changes to make the `Connector` work.