### PR TITLE
fix: Shoukaku headers

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -37,7 +37,7 @@ export const ShoukakuDefaults: Required<ShoukakuOptions> = {
     reconnectInterval: 5,
     restTimeout: 60,
     moveOnDisconnect: false,
-    userAgent: `${Info.name}bot/${Info.version} (${Info.repository.url})`,
+    userAgent: 'Discord Bot/unknown (https://github.com/shipgirlproject/Shoukaku.git)',
     structures: {},
     voiceConnectionTimeout: 15,
     nodeResolver: (nodes) => [ ...nodes.values() ]
@@ -45,6 +45,8 @@ export const ShoukakuDefaults: Required<ShoukakuOptions> = {
         .sort((a, b) => a.penalties - b.penalties)
         .shift()
 };
+
+export const ShoukakuClientInfo = `${Info.name}/${Info.version} (${Info.repository.url})`;
 
 export const NodeDefaults: NodeOption = {
     name: 'Default',

--- a/src/node/Node.ts
+++ b/src/node/Node.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import { IncomingMessage } from 'http';
 import { NodeOption, Shoukaku } from '../Shoukaku';
-import { OpCodes, State, Versions } from '../Constants';
+import { OpCodes, ShoukakuClientInfo, State, Versions } from '../Constants';
 import { wait } from '../Utils';
 import { Rest } from './Rest';
 import { PlayerUpdate, TrackEndEvent, TrackExceptionEvent, TrackStartEvent, TrackStuckEvent, WebSocketClosedEvent } from '../guild/Player';
@@ -208,7 +208,7 @@ export class Node extends EventEmitter {
         this.state = State.CONNECTING;
 
         const headers: NonResumableHeaders|ResumableHeaders = {
-            'Client-Name': this.manager.options.userAgent,
+            'Client-Name': ShoukakuClientInfo,
             'User-Agent': this.manager.options.userAgent,
             'Authorization': this.auth,
             'User-Id': this.manager.id


### PR DESCRIPTION
@Deivu was there any reason for making user agent and client name the same? If not I'll just merge this for correctness. LL docs: https://lavalink.dev/api/websocket#opening-a-connection