### PR TITLE
Ready Event Deprecation Warning

### DIFF
--- a/src/connectors/libs/DiscordJS.ts
+++ b/src/connectors/libs/DiscordJS.ts
@@ -14,7 +14,7 @@ export class DiscordJS extends Connector {
 	// Listen attaches the event listener to the library you are using
 	public listen(nodes: NodeOption[]): void {
 		// Only attach to ready event once, refer to your library for its ready event
-		this.client.once('ready', () => this.ready(nodes));
+		this.client.once('clientReady', () => this.ready(nodes));
 		// Attach to the raw websocket event, this event must be 1:1 on spec with dapi (most libs implement this)
 		this.client.on('raw', (packet: any) => this.raw(packet));
 	}


### PR DESCRIPTION
This pull request addresses the new deprecation warning introduced in discord.js `v14.22`. 

The fix is applied to the v4 branch, which is currently the latest stable release published on npm.