### PR TITLE
feat: plugins support

### DIFF
--- a/docsrc/guide.md
+++ b/docsrc/guide.md
@@ -3,10 +3,11 @@ title: Guide
 children:
   - ./getting-started.md
   - ./options.md
-  - ./common.md
-  - ./plugins.md
   - ./connectors.md
+  - ./common.md
+  - ./wrappers.md
   - ./clustering.md
+  - ./plugins.md
   - ./updating-from-v3.md
   - ./updating-from-v4.md
 ---

--- a/docsrc/plugins.md
+++ b/docsrc/plugins.md
@@ -82,13 +82,34 @@ A plugin filter is passed to `<Player>.getPluginFilter` and `<Player>.setPluginF
 
 You can also directly manipulate `<Player>.filters.pluginFilters` ***without*** type safety (not recommended).
 
-## Plugin WS Events
+## Plugin Events
 Plugin events must implement the `PluginEvent` interface with the following properties:
 - `pluginRequired`: plugin requirement
 - `name`: name of event
 - `T`: type of event object
 
-TODO: ADD EXAMPLE
+Example with [LavaLyrics](https://github.com/topi314/LavaLyrics) `LyricsLineEvent` event
+```ts
+export class LyricsLineEvent implements PluginEvent {
+	public readonly pluginRequired = {
+		name: 'lavalyrics-plugin',
+		version: '^1.1.0'
+	};
+
+	public readonly name = 'LyricsLineEvent';
+
+	public readonly T = t<{
+		lineIndex: number;
+		line: {
+			timestamp: number;
+			duration?: number;
+			line: string;
+			plugin: unknown;
+		};
+		skipped: boolean;
+	}>;
+}
+```
 
 A plugin event is passed to `onPluginEvent` with a callback. Multiple callbacks for the same event is executed sequentially in unknown order.
 

--- a/docsrc/plugins.md
+++ b/docsrc/plugins.md
@@ -1,13 +1,107 @@
 ---
 title: Plugins
 ---
-# Plugins List
-Open a pull request to add your plugin here
+# Plugins
+Lavalink supports plugins that can add filters, REST endpoints, WebSocket events, and more. More information can be found [here](https://lavalink.dev/plugins).
 
-| Name         | Link                                              | Description                                              |
-| ------------ | ------------------------------------------------- | -------------------------------------------------------- |
-| Kazagumo     | [Github](https://github.com/Takiyo0/Kazagumo)     | A wrapper for Shoukaku that has an internal queue system |
-
-## Creating Plugins
+# Using Plugins
 > [!note]
 > This area is under construction.
+
+Shoukaku has support for plugin filters, plugin REST endpoints, and plugin WebSocket events. It may be possible to support plugins that modify the Lavalink API in other ways by extending and modifying the `Rest` and `Player` classes and passing them to `options.structures` when creating a new Shoukaku instance.
+
+Using these abstractions may have introduce a performance penalty.
+
+## Plugin Routes
+Plugin routes must implement the `RestEndpoint` interface with the following properties:
+- `pluginRequired`: plugin requirement
+- `endpoint`: endpoint of route
+- `method`: HTTP request method, `GET` by default
+- `headers`: request headers
+- `params`: URL query parameters
+- `body`: JSON body, ignored when `endpoint` is `GET` or `HEAD`
+- `T`: return type of response
+
+All properties all optional except `endpoint`.
+
+`headers`, `params`, and `body` can be functions that return an object, which allows getting arguments from the class constructor, or a plain object.
+
+Example with [LavaSearch](https://github.com/topi314/LavaSearch) `/loadsearch` endpoint
+```ts
+export class LoadSearchEndpoint implements RestEndpoint {
+	constructor(public readonly query: string, public readonly types: string) {}
+
+	public readonly pluginRequired = {
+		name: 'lavasearch-plugin',
+		version: '^1.0.0'
+	};
+
+	public readonly endpoint = '/loadsearch';
+	public readonly params = () => ({ query: this.query, types: this.types });
+
+	public readonly T = t<{
+		tracks?: Track[];
+		albums?: Playlist[];
+		artists?: Playlist[];
+		playlists?: Playlist[];
+		texts?: {
+			text: string;
+			plugin: Record<string, unknown>;
+		};
+		plugin: Record<string, unknown>;
+	}>;
+}
+```
+
+The plugin route can be passed to `<Rest>.client.fetch`.
+
+You can also use `<Rest>.fetch` to make requests to plugin routes.
+
+## Plugin Filters
+Plugin filters must implement the `PluginFilter` interface with the following properties:
+- `pluginRequired`: plugin requirement
+- `name`: name of filter
+- `T`: type of filter object
+
+Example with [LavaDSPX](https://github.com/Devoxin/LavaDSPX-Plugin) `high-pass` filter
+```ts
+	export class LavaDSPXHighPass implements PluginFilter {
+		public readonly pluginRequired = {
+			name: 'lavadspx-plugin',
+			version: '^0.0.5'
+		};
+		public readonly name = 'high-pass';
+		public readonly T = t<{
+			cutoffFrequency: number;
+			boostFactor: number;
+		}>;
+	}
+```
+
+A plugin filter is passed to `<Player>.getPluginFilter` and `<Player>.setPluginFilter`.
+
+You can also directly manipulate `<Player>.filters.pluginFilters` ***without*** type safety (not recommended).
+
+## Plugin WS Events
+Plugin events must implement the `PluginEvent` interface with the following properties:
+- `pluginRequired`: plugin requirement
+- `name`: name of event
+- `T`: type of event object
+
+TODO: ADD EXAMPLE
+
+A plugin event is passed to `onPluginEvent` with a callback. Multiple callbacks for the same event is executed sequentially in unknown order.
+
+You can also directly listen to the `raw` event on `Node` and check for `op` code `event` and the value of `type` to handle plugin events.
+
+## Additional Information
+
+### The `T` field
+The `T` field is a hack to work around TypeScript types not existing at runtime. 
+
+Using the provided `t` utility function for this field, you can specify a type in the type parameter, e.g. `t<string>`.
+
+### Requiring plugins on the Lavalink server
+The `pluginRequired` property allows specifying the name of the plugin required, and the version as an npm style semver range. To accept any version, use `*`. More information can be found [here](https://semver.npmjs.com/#syntax-examples).
+
+When the plugin is not found or does not satisfy the version range, a `PluginError` is thrown.

--- a/docsrc/wrappers.md
+++ b/docsrc/wrappers.md
@@ -1,0 +1,11 @@
+---
+title: Wrappers
+---
+# Wrappers
+Shoukaku is a barebones Lavalink client. You may want to use a package that extends Shoukaku with more features, such as a queue.
+
+Open a pull request to add your wrapper here.
+
+| Name         | Link                                              | Description                                              |
+| ------------ | ------------------------------------------------- | -------------------------------------------------------- |
+| Kazagumo     | [Github](https://github.com/Takiyo0/Kazagumo)     | A wrapper for Shoukaku that has an internal queue system |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
+        "compare-versions": "^6.1.1",
         "ws": "^8.19.0"
       },
       "devDependencies": {
@@ -2268,6 +2269,12 @@
       "engines": {
         "node": ">= 12.0.0"
       }
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "url": "https://github.com/shipgirlproject/Shoukaku.git"
   },
   "dependencies": {
+    "compare-versions": "^6.1.1",
     "ws": "^8.19.0"
   },
   "devDependencies": {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -34,7 +34,7 @@ export type Constructor<T> = new (...args: unknown[]) => T;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function mergeDefault<T extends Record<string, any>>(def: T, given: T): Required<T> {
 	if (!given) return def as Required<T>;
-	const defaultKeys: (keyof T)[] = Object.keys(def);
+	const defaultKeys: Array<keyof T> = Object.keys(def);
 	for (const key in given) {
 		if (defaultKeys.includes(key)) continue;
 		delete given[key];

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'node:events';
-// import { Rest } from './node/Rest';
 
 // https://stackoverflow.com/a/67244127
 export abstract class TypedEventEmitter<T extends Record<string, unknown[]>> extends EventEmitter {
@@ -35,7 +34,7 @@ export type Constructor<T> = new (...args: unknown[]) => T;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function mergeDefault<T extends Record<string, any>>(def: T, given: T): Required<T> {
 	if (!given) return def as Required<T>;
-	const defaultKeys: Array<keyof T> = Object.keys(def);
+	const defaultKeys: (keyof T)[] = Object.keys(def);
 	for (const key in given) {
 		if (defaultKeys.includes(key)) continue;
 		delete given[key];
@@ -57,23 +56,3 @@ export function mergeDefault<T extends Record<string, any>>(def: T, given: T): R
 export function wait(ms: number): Promise<void> {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Head<T extends any[]> = Required<T> extends [ ...infer R, unknown ] ? R : never;
-
-// type GenericConstructor<T = object> = new (...args: unknown[]) => T;
-// type ConstrainedRestBase = GenericConstructor<Rest>;
-
-// export type ExtendRestFns = Record<string, (this: Rest, ...args: unknown[]) => unknown>;
-
-// export function extendRest(extensions: ExtendRestFns) {
-// 	return class extends Rest {
-// 		constructor(...args: ConstructorParameters<typeof Rest>) {
-// 			super(...args);
-// 			for (const [ name, func ] of Object.entries(extensions)) {
-// 				// @ts-expect-error dynamic assignment
-// 				this[name] = func.bind(this);
-// 			}
-// 		}
-// 	};
-// }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -62,6 +62,12 @@ export function wait(ms: number): Promise<void> {
 // https://stackoverflow.com/a/73753173
 export type HintedString<KnownValues extends string> = (string & {}) | KnownValues;
 
+/**
+ * Utility for specifying types in generic interfaces, workaround for TypeScript types not existing at runtime
+ * @typeParam T Type
+ */
+export const t = <T>(type: unknown) => type as T;
+
 export interface PluginRequirement{
 	/**
 	 * Name of plugin required

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events';
+// import { Rest } from './node/Rest';
 
 // https://stackoverflow.com/a/67244127
 export abstract class TypedEventEmitter<T extends Record<string, unknown[]>> extends EventEmitter {
@@ -56,3 +57,23 @@ export function mergeDefault<T extends Record<string, any>>(def: T, given: T): R
 export function wait(ms: number): Promise<void> {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Head<T extends any[]> = Required<T> extends [ ...infer R, unknown ] ? R : never;
+
+// type GenericConstructor<T = object> = new (...args: unknown[]) => T;
+// type ConstrainedRestBase = GenericConstructor<Rest>;
+
+// export type ExtendRestFns = Record<string, (this: Rest, ...args: unknown[]) => unknown>;
+
+// export function extendRest(extensions: ExtendRestFns) {
+// 	return class extends Rest {
+// 		constructor(...args: ConstructorParameters<typeof Rest>) {
+// 			super(...args);
+// 			for (const [ name, func ] of Object.entries(extensions)) {
+// 				// @ts-expect-error dynamic assignment
+// 				this[name] = func.bind(this);
+// 			}
+// 		}
+// 	};
+// }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,4 +1,6 @@
 import { EventEmitter } from 'node:events';
+import { satisfies, validateStrict } from 'compare-versions';
+import type { NodeInfoPlugin } from './node/Node';
 
 // https://stackoverflow.com/a/67244127
 export abstract class TypedEventEmitter<T extends Record<string, unknown[]>> extends EventEmitter {
@@ -59,3 +61,46 @@ export function wait(ms: number): Promise<void> {
 
 // https://stackoverflow.com/a/73753173
 export type HintedString<KnownValues extends string> = (string & {}) | KnownValues;
+
+export interface PluginRequirement{
+	/**
+	 * Name of plugin required
+	 */
+	readonly name: string;
+	/**
+	 * Version of plugin required, any string or npm style semver range
+	 * @see https://semver.npmjs.com/#syntax-examples
+	 */
+	readonly version: string;
+}
+
+export class PluginError extends Error {
+	constructor(
+		readonly requiredFor: string,
+		readonly required: PluginRequirement,
+		readonly found?: NodeInfoPlugin
+	) {
+		super(`Plugin ${required.name}@${required.version} is required for ${requiredFor}, but ${found ? `found ${found.name}@${found.version}` : 'was not found'}`);
+		this.name = 'PluginError';
+		Object.setPrototypeOf(this, new.target.prototype);
+	}
+}
+
+/**
+ * Validate if plugins present in node meets specified plugin requirements
+ * @param requiredFor specifies what requires the plugin
+ * @param required plugin requirements
+ * @param nodePlugins plugins present in node
+ * @throws {@link PluginError} when plugin is not found or does not satisfy version
+ * @internal
+ */
+export function validatePluginRequirement(requiredFor: string, required: PluginRequirement, nodePlugins?: NodeInfoPlugin[]) {
+	const found = nodePlugins?.find((p => p.name === required.name));
+
+	const isValid = !!found
+	    && (validateStrict(required.version)
+	    	? satisfies(found.version, required.version)
+	    	: found?.version === required.version);
+
+	if (!isValid) throw new PluginError(requiredFor, required, found);
+}

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -65,12 +65,50 @@ export type HintedString<KnownValues extends string> = (string & {}) | KnownValu
 /**
  * Utility for specifying types in generic interfaces, workaround for TypeScript types not existing at runtime
  * @typeParam T Type of value
+ * @internal
  */
 export const t = <T>(type: unknown) => type as T;
 
 /**
+ * @internal
+ */
+export type TFn = (type: unknown) => unknown;
+
+/**
+ * @internal
+ */
+export interface TField {
+	/**
+	 * This hack is to work around TypeScript types not existing at runtime.
+	 * We can specify the return type here.
+	 * 
+	 * @example
+	 * This function is never actually called, so the implementation can be simply:
+	 * ```
+	 * T = (response: unknown) => response as LavalinkResponse;
+	 * ```
+	 * 
+	 * @example
+	 * Or using the `t` utility function
+	 * ```
+	 * import { t } from 'shoukaku';
+	 * 
+	 * T = t<LavalinkResponse>;
+	 * ```
+	 */
+	readonly T: TFn;
+};
+
+/**
+ * Get the type specified in the T field
+ * @internal
+ */
+export type TReturnType<T extends TField> = ReturnType<T['T']>;
+
+/**
  * Function that returns a value or value
  * @typeParam T Type of value
+ * @internal
  */
 export type FnOrVal<T> = T | (() => T);
 
@@ -78,12 +116,13 @@ export type FnOrVal<T> = T | (() => T);
  * Get the value from a {@link FnOrVal}
  * @param input Input function or value
  * @returns Value as specified by T, you must explicitly assert non-optional values are not `undefined` since properties may be optional
+ * @internal
  */
 export function fnOrVal<T>(input?: FnOrVal<T>): T | undefined {
 	return typeof input === 'function' ? (input as () => T)?.() : input;
 }
 
-export interface PluginRequirement{
+export interface PluginRequirement {
 	/**
 	 * Name of plugin required
 	 */

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -64,9 +64,24 @@ export type HintedString<KnownValues extends string> = (string & {}) | KnownValu
 
 /**
  * Utility for specifying types in generic interfaces, workaround for TypeScript types not existing at runtime
- * @typeParam T Type
+ * @typeParam T Type of value
  */
 export const t = <T>(type: unknown) => type as T;
+
+/**
+ * Function that returns a value or value
+ * @typeParam T Type of value
+ */
+export type FnOrVal<T> = T | (() => T);
+
+/**
+ * Get the value from a {@link FnOrVal}
+ * @param input Input function or value
+ * @returns Value as specified by T, you must explicitly assert non-optional values are not `undefined` since properties may be optional
+ */
+export function fnOrVal<T>(input?: FnOrVal<T>): T | undefined {
+	return typeof input === 'function' ? (input as () => T)?.() : input;
+}
 
 export interface PluginRequirement{
 	/**

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -136,9 +136,9 @@ export interface PluginRequirement {
 
 export class PluginError extends Error {
 	constructor(
-		readonly requiredFor: string,
-		readonly required: PluginRequirement,
-		readonly found?: NodeInfoPlugin
+		public readonly requiredFor: string,
+		public readonly required: PluginRequirement,
+		public readonly found?: NodeInfoPlugin
 	) {
 		super(`Plugin ${required.name}@${required.version} is required for ${requiredFor}, but ${found ? `found ${found.name}@${found.version}` : 'was not found'}`);
 		this.name = 'PluginError';

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -56,3 +56,6 @@ export function mergeDefault<T extends Record<string, any>>(def: T, given: T): R
 export function wait(ms: number): Promise<void> {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+// https://stackoverflow.com/a/73753173
+export type HintedString<KnownValues extends string> = (string & {}) | KnownValues;

--- a/src/guild/Player.ts
+++ b/src/guild/Player.ts
@@ -198,7 +198,7 @@ export interface PluginFilter {
 	 * This hack is to work around TypeScript types not existing at runtime.
 	 * We can specify the filter data type here.
 	 */
-	readonly D: (data: unknown) => unknown;
+	readonly T: (data: unknown) => unknown;
 }
 
 export interface PluginEvent {
@@ -214,7 +214,7 @@ export interface PluginEvent {
 	 * This hack is to work around TypeScript types not existing at runtime.
 	 * We can specify the filter data type here.
 	 */
-	readonly D: (data: unknown) => unknown;
+	readonly T: (data: unknown) => unknown;
 }
 
 /**
@@ -455,7 +455,7 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 	 */
 	public getPluginFilter<
 		F extends PluginFilter,
-		D = ReturnType<F['D']>
+		D = ReturnType<F['T']>
 	>(filter: F): D | undefined {
 		// TODO: should we check for plugins here? we shouldn't need to since it returns undefined
 		return this.filters.pluginFilters?.[filter.name] as D;
@@ -469,7 +469,7 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 	 */
 	public async setPluginFilter<
 		F extends PluginFilter,
-		D = ReturnType<F['D']>
+		D = ReturnType<F['T']>
 	>(filter: F, data?: D): Promise<void> {
 		// TODO: should we check for plugins (name, version) or the filters list instead?
 		// TODO: should we cache the plugin check somehow?
@@ -642,7 +642,7 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 
 	public onPluginEvent<
 		E extends PluginEvent,
-		D = ReturnType<E['D']> & PlayerEvent & { type: E['name'] }
+		D = ReturnType<E['T']> & PlayerEvent & { type: E['name'] }
 	>(plugin: PluginEvent, callback: (data: D) => void) {
 		// TODO: insert plugin check here maybe? but its async
 

--- a/src/guild/Player.ts
+++ b/src/guild/Player.ts
@@ -1,7 +1,7 @@
 import { OpCodes, State } from '../Constants';
 import type { Node } from '../node/Node';
 import type { Exception, Track, UpdatePlayerInfo, UpdatePlayerOptions } from '../node/Rest';
-import { TypedEventEmitter } from '../Utils';
+import { PluginRequirement, TypedEventEmitter, validatePluginRequirement } from '../Utils';
 import { Connection } from './Connection';
 
 export type TrackEndReason = 'finished' | 'loadFailed' | 'stopped' | 'replaced' | 'cleanup';
@@ -121,6 +121,8 @@ export interface FilterOptions {
 	distortion?: DistortionSettings | null;
 	channelMix?: ChannelMixSettings | null;
 	lowPass?: LowPassSettings | null;
+	// TODO: check this, im assuming null unsets everything?
+	pluginFilters?: Record<string, unknown> | null;
 }
 
 // Interfaces are not final, but types are, and therefore has an index signature
@@ -163,6 +165,41 @@ export type PlayerEvents = {
 	 */
 	'update': [data: PlayerUpdate];
 };
+
+/**
+ * Plugin filters should implement this interface to use with {@link Player#setPluginFilter}
+ * 
+ * @example
+ * Example with [LavaDSPX](https://github.com/Devoxin/LavaDSPX-Plugin) `high-pass` filter
+ * ```
+ *	export class LavaDSPXHighPass implements PluginFilter {
+ *		public readonly pluginRequired = {
+ *			name: 'lavadspx-plugin',
+ *			version: '^0.0.5'
+ *		};
+ *		public readonly name = 'high-pass';
+ *		public readonly D = t<{
+ *			cutoffFrequency: number;
+ *			boostFactor: number;
+ *		}>;
+ *	}
+ * ```
+ */
+export interface PluginFilter {
+	/**
+	 * Plugin required by filter
+	 */
+	readonly pluginRequired?: PluginRequirement;
+	/**
+	 * Name of filter
+	 */
+	readonly name: string;
+	/**
+	 * This hack is to work around TypeScript types not existing at runtime.
+	 * We can specify the filter data type here.
+	 */
+	readonly D: (data: unknown) => unknown;
+}
 
 /**
  * Wrapper object around Lavalink
@@ -393,6 +430,37 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 	}
 
 	/**
+	 * Get the value of a plugin defined filter
+	 * @param filter Plugin filter config (see {@link PluginFilter})
+	 * @returns Filter object as specified by the `D` function
+	 */
+	public getPluginFilter<
+		F extends PluginFilter,
+		D = PluginFilter['D']
+	>(filter: F): D | undefined {
+		// TODO: should we check for plugins here? we shouldn't need to since it returns undefined
+		return this.filters.pluginFilters?.[filter.name] as D;
+	}
+
+	/**
+	 * Set a plugin defined filter
+	 * @param filter Plugin filter config (see {@link PluginFilter})
+	 * @param data Filter object as specified by the `D` function
+	 * @throws {@link PluginError} when plugin required by the filter is not satisfied by plugins on this node
+	 */
+	public async setPluginFilter<
+		F extends PluginFilter,
+		D = PluginFilter['D']
+	>(filter: F, data?: D): Promise<void> {
+		// TODO: should we check for plugins (name, version) or the filters list instead?
+		// TODO: should we cache the plugin check somehow?
+		if (filter.pluginRequired)
+			validatePluginRequirement(`filter ${filter.name}`, filter.pluginRequired, await this.node.rest.client._getNodePlugins());
+
+		return this.setFilters({ pluginFilters: { [filter.name]: data ?? null }});
+	}
+
+	/**
 	 * Change the all filter settings applied to the currently playing track
 	 * @param filters An object that conforms to FilterOptions that defines all filters to apply/modify
 	 */
@@ -414,7 +482,8 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 			rotation: null,
 			distortion: null,
 			channelMix: null,
-			lowPass: null
+			lowPass: null,
+			pluginFilters: null
 		});
 	}
 

--- a/src/guild/Player.ts
+++ b/src/guild/Player.ts
@@ -201,6 +201,22 @@ export interface PluginFilter {
 	readonly D: (data: unknown) => unknown;
 }
 
+export interface PluginEvent {
+	/**
+	 * Plugin required by event
+	 */
+	readonly pluginRequired?: PluginRequirement;
+	/**
+	 * Name of event
+	 */
+	readonly name: string;
+	/**
+	 * This hack is to work around TypeScript types not existing at runtime.
+	 * We can specify the filter data type here.
+	 */
+	readonly D: (data: unknown) => unknown;
+}
+
 /**
  * Wrapper object around Lavalink
  */
@@ -237,6 +253,9 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 	 * Filters on current track
 	 */
 	public filters: FilterOptions;
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	private pluginEvents: Record<string, Array<(data: any) => void> | undefined> = {};
 
 	constructor(guildId: string, node: Node) {
 		super();
@@ -549,6 +568,7 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 		this.volume = 100;
 		this.position = 0;
 		this.filters = {};
+		this.pluginEvents = {};
 	}
 
 	/**
@@ -604,11 +624,29 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 				this.emit('closed', json);
 				break;
 			default:
-				this.node.manager.emit(
-					'debug',
-					this.node.name,
-					`[Player] -> [Node] : Unknown Player Event Type, Data => ${JSON.stringify(json)}`
-				);
+				if ((json as { type: string }).type in this.pluginEvents) {
+					for (const callback of this.pluginEvents[(json as { type: string }).type]!) {
+						try {
+							callback(json);
+						} catch { /* empty */ }
+					}
+				} else {
+					this.node.manager.emit(
+						'debug',
+						this.node.name,
+						`[Player] -> [Node] : Unknown Player Event Type, Data => ${JSON.stringify(json)}`
+					);
+				}
 		}
+	}
+
+	public onPluginEvent<
+		E extends PluginEvent,
+		D = E['D'] & PlayerEvent & { type: E['name'] }
+	>(plugin: PluginEvent, callback: (data: D) => void) {
+		// TODO: insert plugin check here maybe? but its async
+
+		this.pluginEvents[plugin.name] ??= [];
+		this.pluginEvents[plugin.name]?.push(callback);
 	}
 }

--- a/src/guild/Player.ts
+++ b/src/guild/Player.ts
@@ -1,7 +1,7 @@
 import { OpCodes, State } from '../Constants';
 import type { Node } from '../node/Node';
 import type { Exception, Track, UpdatePlayerInfo, UpdatePlayerOptions } from '../node/Rest';
-import { PluginRequirement, TypedEventEmitter, validatePluginRequirement } from '../Utils';
+import { PluginRequirement, TField, TReturnType, TypedEventEmitter, validatePluginRequirement } from '../Utils';
 import { Connection } from './Connection';
 
 export type TrackEndReason = 'finished' | 'loadFailed' | 'stopped' | 'replaced' | 'cleanup';
@@ -185,7 +185,7 @@ export type PlayerEvents = {
  *	}
  * ```
  */
-export interface PluginFilter {
+export interface PluginFilter extends TField {
 	/**
 	 * Plugin required by filter
 	 */
@@ -194,14 +194,9 @@ export interface PluginFilter {
 	 * Name of filter
 	 */
 	readonly name: string;
-	/**
-	 * This hack is to work around TypeScript types not existing at runtime.
-	 * We can specify the filter data type here.
-	 */
-	readonly T: (data: unknown) => unknown;
 }
 
-export interface PluginEvent {
+export interface PluginEvent extends TField {
 	/**
 	 * Plugin required by event
 	 */
@@ -210,11 +205,6 @@ export interface PluginEvent {
 	 * Name of event
 	 */
 	readonly name: string;
-	/**
-	 * This hack is to work around TypeScript types not existing at runtime.
-	 * We can specify the filter data type here.
-	 */
-	readonly T: (data: unknown) => unknown;
 }
 
 /**
@@ -455,7 +445,7 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 	 */
 	public getPluginFilter<
 		F extends PluginFilter,
-		D = ReturnType<F['T']>
+		D = TReturnType<F>
 	>(filter: F): D | undefined {
 		// TODO: should we check for plugins here? we shouldn't need to since it returns undefined
 		return this.filters.pluginFilters?.[filter.name] as D;
@@ -469,7 +459,7 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 	 */
 	public async setPluginFilter<
 		F extends PluginFilter,
-		D = ReturnType<F['T']>
+		D = TReturnType<F>
 	>(filter: F, data?: D): Promise<void> {
 		// TODO: should we check for plugins (name, version) or the filters list instead?
 		// TODO: should we cache the plugin check somehow?
@@ -649,7 +639,7 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 
 	public onPluginEvent<
 		E extends PluginEvent,
-		D = ReturnType<E['T']> & PlayerEvent & { type: E['name'] }
+		D = TReturnType<E> & PlayerEvent & { type: E['name'] }
 	>(plugin: PluginEvent, callback: (data: D) => void) {
 		// TODO: insert plugin check here maybe? but its async
 		// plugin event callback is never called if LL does not

--- a/src/guild/Player.ts
+++ b/src/guild/Player.ts
@@ -436,7 +436,7 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 	 */
 	public getPluginFilter<
 		F extends PluginFilter,
-		D = PluginFilter['D']
+		D = F['D']
 	>(filter: F): D | undefined {
 		// TODO: should we check for plugins here? we shouldn't need to since it returns undefined
 		return this.filters.pluginFilters?.[filter.name] as D;
@@ -450,7 +450,7 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 	 */
 	public async setPluginFilter<
 		F extends PluginFilter,
-		D = PluginFilter['D']
+		D = F['D']
 	>(filter: F, data?: D): Promise<void> {
 		// TODO: should we check for plugins (name, version) or the filters list instead?
 		// TODO: should we cache the plugin check somehow?

--- a/src/guild/Player.ts
+++ b/src/guild/Player.ts
@@ -623,12 +623,18 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 			case PlayerEventType.WEBSOCKET_CLOSED_EVENT:
 				this.emit('closed', json);
 				break;
-			default:
-				if ((json as { type: string }).type in this.pluginEvents) {
-					for (const callback of this.pluginEvents[(json as { type: string }).type]!) {
+			default: {
+				// TODO: fix types for json
+				const { type } = json as { type: string };
+				if (type in this.pluginEvents) {
+					// these run sequentially in unknown order (bad?)
+					// TODO: should we check if this.pluginEvents[type] is interable? will throw TypeError
+					for (const callback of this.pluginEvents[type]!) {
 						try {
 							callback(json);
-						} catch { /* empty */ }
+						} catch {
+							// TODO: should we rethrow error here?
+						}
 					}
 				} else {
 					this.node.manager.emit(
@@ -637,6 +643,7 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 						`[Player] -> [Node] : Unknown Player Event Type, Data => ${JSON.stringify(json)}`
 					);
 				}
+			}
 		}
 	}
 
@@ -645,6 +652,8 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 		D = ReturnType<E['T']> & PlayerEvent & { type: E['name'] }
 	>(plugin: PluginEvent, callback: (data: D) => void) {
 		// TODO: insert plugin check here maybe? but its async
+		// plugin event callback is never called if LL does not
+		// send event so may cause confusion
 
 		this.pluginEvents[plugin.name] ??= [];
 		this.pluginEvents[plugin.name]?.push(callback);

--- a/src/guild/Player.ts
+++ b/src/guild/Player.ts
@@ -196,6 +196,33 @@ export interface PluginFilter extends TField {
 	readonly name: string;
 }
 
+/**
+ * Plugin events should implement this interface to use with {@link Player#onPluginEvent}
+ * 
+ * @example
+ * Example with [LavaLyrics](https://github.com/topi314/LavaLyrics) `LyricsLineEvent` event
+ * ```
+ *	export class LyricsLineEvent implements PluginEvent {
+ *		public readonly pluginRequired = {
+ *			name: 'lavalyrics-plugin',
+ *			version: '^1.1.0'
+ *		};
+ * 
+ *		public readonly name = 'LyricsLineEvent';
+ * 
+ *		public readonly T = t<{
+ *			lineIndex: number;
+ *			line: {
+ *				timestamp: number;
+ *				duration?: number;
+ *				line: string;
+ *				plugin: unknown;
+ *			};
+ *			skipped: boolean;
+ *		}>;
+ *	}
+ *	```
+ */
 export interface PluginEvent extends TField {
 	/**
 	 * Plugin required by event

--- a/src/guild/Player.ts
+++ b/src/guild/Player.ts
@@ -178,7 +178,7 @@ export type PlayerEvents = {
  *			version: '^0.0.5'
  *		};
  *		public readonly name = 'high-pass';
- *		public readonly D = t<{
+ *		public readonly T = t<{
  *			cutoffFrequency: number;
  *			boostFactor: number;
  *		}>;

--- a/src/guild/Player.ts
+++ b/src/guild/Player.ts
@@ -455,7 +455,7 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 	 */
 	public getPluginFilter<
 		F extends PluginFilter,
-		D = F['D']
+		D = ReturnType<F['D']>
 	>(filter: F): D | undefined {
 		// TODO: should we check for plugins here? we shouldn't need to since it returns undefined
 		return this.filters.pluginFilters?.[filter.name] as D;
@@ -469,7 +469,7 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 	 */
 	public async setPluginFilter<
 		F extends PluginFilter,
-		D = F['D']
+		D = ReturnType<F['D']>
 	>(filter: F, data?: D): Promise<void> {
 		// TODO: should we check for plugins (name, version) or the filters list instead?
 		// TODO: should we cache the plugin check somehow?
@@ -642,7 +642,7 @@ export class Player extends TypedEventEmitter<PlayerEvents> {
 
 	public onPluginEvent<
 		E extends PluginEvent,
-		D = E['D'] & PlayerEvent & { type: E['name'] }
+		D = ReturnType<E['D']> & PlayerEvent & { type: E['name'] }
 	>(plugin: PluginEvent, callback: (data: D) => void) {
 		// TODO: insert plugin check here maybe? but its async
 

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -212,7 +212,7 @@ export interface RestEndpoint {
 	 * R = (response: unknown) => response as LavalinkResponse;
 	 * ```
 	 */
-	R(response: unknown): unknown;
+	readonly R: (response: unknown) => unknown;
 };
 
 export class NoopMiddleware implements RestMiddleware {}
@@ -331,7 +331,7 @@ export class ResolveEndpoint implements RestEndpoint {
 	public readonly endpoint = '/loadtracks';
 	public readonly params = () => ({ identifier: this.identifier });
 
-	public R = t<LavalinkResponse>;
+	public readonly R = t<LavalinkResponse>;
 }
 
 export class DecodeEndpoint implements RestEndpoint {
@@ -340,7 +340,7 @@ export class DecodeEndpoint implements RestEndpoint {
 	public readonly endpoint = '/decodetrack';
 	public readonly params = () => ({ track: this.track });
 
-	public R = t<Track>;
+	public readonly R = t<Track>;
 }
 
 export class GetPlayersEndpoint implements RestEndpoint {
@@ -348,7 +348,7 @@ export class GetPlayersEndpoint implements RestEndpoint {
 
 	public readonly endpoint = () => `/sessions/${this.sessionId}/players`;
 
-	public R = t<LavalinkPlayer[]>;
+	public readonly R = t<LavalinkPlayer[]>;
 }
 
 export class GetPlayerEndpoint implements RestEndpoint {
@@ -356,7 +356,7 @@ export class GetPlayerEndpoint implements RestEndpoint {
 
 	public readonly endpoint = () => `/sessions/${this.sessionId}/players/${this.guildId}`;
 
-	public R = t<LavalinkPlayer>;
+	public readonly R = t<LavalinkPlayer>;
 }
 
 export class UpdatePlayerEndpoint implements RestEndpoint {
@@ -369,7 +369,7 @@ export class UpdatePlayerEndpoint implements RestEndpoint {
 	public readonly headers = { 'Content-Type': 'application/json' };
 	public readonly body = () => this.data.playerOptions as Record<string, unknown>;
 
-	public R = t<LavalinkPlayer>;
+	public readonly R = t<LavalinkPlayer>;
 }
 
 export class DestroyPlayerEndpoint implements RestEndpoint {
@@ -379,7 +379,7 @@ export class DestroyPlayerEndpoint implements RestEndpoint {
 
 	public readonly method = 'DELETE';
 
-	public R = t<void>;
+	public readonly R = t<void>;
 }
 
 export class UpdateSessionEndpoint implements RestEndpoint {
@@ -395,19 +395,19 @@ export class UpdateSessionEndpoint implements RestEndpoint {
 	public readonly headers = { 'Content-Type': 'application/json' };
 	public readonly body = () => ({ resuming: this.resuming, timeout: this.timeout });
 
-	public R = t<SessionInfo>;
+	public readonly R = t<SessionInfo>;
 }
 
 export class StatsEndpoint implements RestEndpoint {
 	public readonly endpoint = '/stats';
 
-	public R = t<Stats>;
+	public readonly R = t<Stats>;
 }
 
 export class RoutePlannerStatusEndpoint implements RestEndpoint {
 	public readonly endpoint = '/routeplanner/status';
 
-	public R = t<RoutePlanner>;
+	public readonly R = t<RoutePlanner>;
 }
 
 export class UnmarkFailedAddressEndpoint implements RestEndpoint {
@@ -419,7 +419,7 @@ export class UnmarkFailedAddressEndpoint implements RestEndpoint {
 	public readonly headers = { 'Content-Type': 'application/json' };
 	public readonly body = () => ({ address: this.address });
 
-	public R = t<void>;
+	public readonly R = t<void>;
 }
 
 export class LavalinkInfoEndpoint implements RestEndpoint {
@@ -427,7 +427,7 @@ export class LavalinkInfoEndpoint implements RestEndpoint {
 
 	public readonly headers = { 'Content-Type': 'application/json' };
 
-	public R = t<NodeInfo>;
+	public readonly R = t<NodeInfo>;
 }
 
 /**
@@ -584,7 +584,7 @@ export class Rest {
 			public readonly params = fetchOptions.options.params;
 			public readonly body = fetchOptions.options.body;
 
-			public R = t<T>;
+			public readonly R = t<T>;
 		});
 	}
 }

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -1,6 +1,7 @@
 import { Versions } from '../Constants';
 import type { FilterOptions } from '../guild/Player';
 import type { NodeOption } from '../Shoukaku';
+import { Head } from '../Utils';
 import type { Node, NodeInfo, Stats } from './Node';
 
 export type Severity = 'common' | 'suspicious' | 'fault';
@@ -161,10 +162,21 @@ interface FinalFetchOptions {
 	body?: string;
 }
 
+export interface PluginConfig {
+	serverPlugin: string;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	function: (rest: Rest, ...args: any[]) => unknown;
+}
+
+// https://stackoverflow.com/a/58764959
+type OmitRestArg<F extends PluginConfig['function']> = F extends (rest: Rest, ...args: infer P) => infer R ? (...args: P) => R : never;
+
+export type Plugins = Record<string, PluginConfig>;
+
 /**
  * Wrapper around Lavalink REST API
  */
-export class Rest {
+export class Rest<TPlugins extends Plugins = {}> {
 	/**
 	 * Node that initialized this instance
 	 */
@@ -177,6 +189,9 @@ export class Rest {
 	 * Credentials to access Lavalink
 	 */
 	protected readonly auth: string;
+
+	protected readonly plugins: TPlugins = {} as TPlugins;
+
 	/**
 	 * @param node An instance of Node
 	 * @param options The options to initialize this rest class
@@ -186,10 +201,36 @@ export class Rest {
 	 * @param options.secure Weather to use secure protocols or not
 	 * @param options.group Group of this node
 	 */
-	constructor(node: Node, options: NodeOption) {
+	constructor(node: Node, options: NodeOption, plugins?: Plugins) {
 		this.node = node;
 		this.url = `${options.secure ? 'https' : 'http'}://${options.url}/v${Versions.REST_VERSION}`;
 		this.auth = options.auth;
+		(this.plugins as Plugins) = plugins ?? {};
+		return this as Rest<TPlugins & (typeof plugins extends Plugins ? typeof plugins : {})>;
+	}
+
+	static extend(plugins: (PluginConfig & { name: string })[]) {
+		const pluginsObj = Object.fromEntries(plugins?.map(({ name, ...config }) => [ name, { ...config }]));
+		return class extends Rest {
+			constructor(...args: Head<ConstructorParameters<typeof Rest>>) {
+				super(...args, pluginsObj);
+			}
+		};
+	}
+
+	// extend<TName extends string, TPluginConfig extends PluginConfig>(
+	// 	name: TName,
+	// 	pluginConfig: TPluginConfig
+	// ): Rest<TPlugins & Record<TName, TPluginConfig>> {
+	// 	(this.plugins as Plugins)[name] = pluginConfig;
+	// 	return this as unknown as Rest<TPlugins & Record<TName, TPluginConfig>>;
+	// }
+
+	plugin<TPlugin extends keyof TPlugins>(
+		name: TPlugin,
+		...args: Parameters<OmitRestArg<TPlugins[TPlugin]['function']>>
+	): ReturnType<TPlugins[TPlugin]['function']> {
+		return this.plugins[name].function(this, ...args) as ReturnType<TPlugins[TPlugin]['function']>;
 	}
 
 	protected get sessionId(): string {

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -221,7 +221,7 @@ export class NoopMiddleware implements RestMiddleware {}
  * Exendable generic REST client to make requests to Lavalink
  */
 export class RestClient<T extends RestMiddleware = NoopMiddleware> {
-	protected _nodePlugins?: NodeInfoPlugin[];
+	protected nodePlugins?: NodeInfoPlugin[];
 
 	/**
 	 * @param auth Credentials to access Lavalnk
@@ -240,13 +240,18 @@ export class RestClient<T extends RestMiddleware = NoopMiddleware> {
 		return this as RestClient<typeof middleware>;
 	}
 
-	private async getNodePlugins() {
-		if (!this._nodePlugins) {
+	/**
+	 * Get a list of plugins available on this node, you should use {@link Rest#getLavalinkInfo} instead
+	 * @returns A list of plugins
+	 * @internal
+	 */
+	public async _getNodePlugins() {
+		if (!this.nodePlugins) {
 			const info = await this.fetch(new LavalinkInfoEndpoint());
-			this._nodePlugins = info?.plugins ?? [];
+			this.nodePlugins = info?.plugins ?? [];
 		}
 
-		return this._nodePlugins;
+		return this.nodePlugins;
 	}
 
 	/**
@@ -265,7 +270,7 @@ export class RestClient<T extends RestMiddleware = NoopMiddleware> {
 
 		// TODO: should we cache the plugin check somehow?
 		if (endpoint.pluginRequired)
-			validatePluginRequirement(`endpoint ${path}`, endpoint.pluginRequired, await this.getNodePlugins());
+			validatePluginRequirement(`endpoint ${path}`, endpoint.pluginRequired, await this._getNodePlugins());
 
 		const headers = {
 			'Authorization': this.auth,
@@ -449,7 +454,7 @@ export class Rest {
 	/**
 	 * Client to make request to Lavalink
 	 */
-	protected readonly client: RestClient;
+	public readonly client: RestClient;
 	/**
 	 * @param node An instance of Node
 	 * @param options The options to initialize this rest class

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -1,8 +1,8 @@
 import { Versions } from '../Constants';
 import type { FilterOptions } from '../guild/Player';
 import type { NodeOption } from '../Shoukaku';
-import { t, validatePluginRequirement } from '../Utils';
-import type { HintedString, PluginRequirement } from '../Utils';
+import { fnOrVal, t, validatePluginRequirement } from '../Utils';
+import type { FnOrVal, HintedString, PluginRequirement } from '../Utils';
 import type { Node, NodeInfo, NodeInfoPlugin, Stats } from './Node';
 
 export type Severity = 'common' | 'suspicious' | 'fault';
@@ -163,12 +163,6 @@ interface FinalFetchOptions {
 	body?: string;
 }
 
-type FnOrVal<T> = T | (() => T);
-
-function fnOrVal<T>(input?: T | (() => T)): T | undefined {
-	return typeof input === 'function' ? (input as () => T)?.() : input;
-}
-
 /**
  * Inject headers and params globally to a RestClient instance
  */
@@ -199,15 +193,15 @@ export interface RestEndpoint {
 	/**
 	 * HTTP request headers
 	 */
-	readonly headers?: FnOrVal<Record<string, string>>;
+	readonly headers?: FnOrVal<Record<string, string> | undefined>;
 	/**
 	 * URL params
 	 */
-	readonly params?: FnOrVal<Record<string, string>>;
+	readonly params?: FnOrVal<Record<string, string> | undefined>;
 	/**
 	 * JSON body to send with
 	 */
-	readonly body?: FnOrVal<Record<string, unknown>>;
+	readonly body?: FnOrVal<Record<string, unknown> | undefined>;
 	/**
 	 * This hack is to work around TypeScript types not existing at runtime.
 	 * We can specify the return type of the endpoint in the fetch function here.

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -263,7 +263,7 @@ export class RestClient<T extends RestMiddleware = NoopMiddleware> {
 	 * @throws {@link DeserializationError} when parsing response as JSON fails
 	 * @throws {@link PluginError} when plugin required by endpoint is not satisfied by plugins on this node
 	 */
-	async fetch<
+	public async fetch<
 		E extends RestEndpoint,
 		R = ReturnType<E['R']>
 	>(endpoint: E): Promise<R | undefined> {
@@ -336,58 +336,58 @@ export const r = <T>(response: unknown) => response as T;
 export class ResolveEndpoint implements RestEndpoint {
 	constructor (public readonly identifier: string) {}
 
-	readonly endpoint = '/loadtracks';
-	readonly params = () => ({ identifier: this.identifier });
+	public readonly endpoint = '/loadtracks';
+	public readonly params = () => ({ identifier: this.identifier });
 
-	R = r<LavalinkResponse>;
+	public R = r<LavalinkResponse>;
 }
 
 export class DecodeEndpoint implements RestEndpoint {
 	constructor (public readonly track: string) {}
 
-	readonly endpoint = '/decodetrack';
-	readonly params = () => ({ track: this.track });
+	public readonly endpoint = '/decodetrack';
+	public readonly params = () => ({ track: this.track });
 
-	R = r<Track>;
+	public R = r<Track>;
 }
 
 export class GetPlayersEndpoint implements RestEndpoint {
 	constructor (public readonly sessionId: string) {}
 
-	readonly endpoint = () => `/sessions/${this.sessionId}/players`;
+	public readonly endpoint = () => `/sessions/${this.sessionId}/players`;
 
-	R = r<LavalinkPlayer[]>;
+	public R = r<LavalinkPlayer[]>;
 }
 
 export class GetPlayerEndpoint implements RestEndpoint {
 	constructor (public readonly sessionId: string, public readonly guildId: string) {}
 
-	readonly endpoint = () => `/sessions/${this.sessionId}/players/${this.guildId}`;
+	public readonly endpoint = () => `/sessions/${this.sessionId}/players/${this.guildId}`;
 
-	R = r<LavalinkPlayer>;
+	public R = r<LavalinkPlayer>;
 }
 
 export class UpdatePlayerEndpoint implements RestEndpoint {
 	constructor (public readonly sessionId: string, public readonly data: UpdatePlayerInfo) {}
 
-	readonly endpoint = () => `/sessions/${this.sessionId}/players/${this.data.guildId}`;
+	public readonly endpoint = () => `/sessions/${this.sessionId}/players/${this.data.guildId}`;
 
-	readonly method = 'PATCH';
-	readonly params = () => ({ noReplace: this.data.noReplace?.toString() ?? 'false' });
-	readonly headers = { 'Content-Type': 'application/json' };
-	readonly body = () => this.data.playerOptions as Record<string, unknown>;
+	public readonly method = 'PATCH';
+	public readonly params = () => ({ noReplace: this.data.noReplace?.toString() ?? 'false' });
+	public readonly headers = { 'Content-Type': 'application/json' };
+	public readonly body = () => this.data.playerOptions as Record<string, unknown>;
 
-	R = r<LavalinkPlayer>;
+	public R = r<LavalinkPlayer>;
 }
 
 export class DestroyPlayerEndpoint implements RestEndpoint {
 	constructor (public readonly sessionId: string, public readonly guildId: string) {}
 
-	readonly endpoint = () => `/sessions/${this.sessionId}/players/${this.guildId}`;
+	public readonly endpoint = () => `/sessions/${this.sessionId}/players/${this.guildId}`;
 
-	readonly method = 'DELETE';
+	public readonly method = 'DELETE';
 
-	R = r<void>;
+	public R = r<void>;
 }
 
 export class UpdateSessionEndpoint implements RestEndpoint {
@@ -397,45 +397,45 @@ export class UpdateSessionEndpoint implements RestEndpoint {
 		public readonly timeout?: number
 	) {}
 
-	readonly endpoint = () => `/sessions/${this.sessionId}`;
+	public readonly endpoint = () => `/sessions/${this.sessionId}`;
 
-	readonly method = 'PATCH';
-	readonly headers = { 'Content-Type': 'application/json' };
-	readonly body = () => ({ resuming: this.resuming, timeout: this.timeout });
+	public readonly method = 'PATCH';
+	public readonly headers = { 'Content-Type': 'application/json' };
+	public readonly body = () => ({ resuming: this.resuming, timeout: this.timeout });
 
-	R = r<SessionInfo>;
+	public R = r<SessionInfo>;
 }
 
 export class StatsEndpoint implements RestEndpoint {
-	readonly endpoint = '/stats';
+	public readonly endpoint = '/stats';
 
-	R = r<Stats>;
+	public R = r<Stats>;
 }
 
 export class RoutePlannerStatusEndpoint implements RestEndpoint {
-	readonly endpoint = '/routeplanner/status';
+	public readonly endpoint = '/routeplanner/status';
 
-	R = r<RoutePlanner>;
+	public R = r<RoutePlanner>;
 }
 
 export class UnmarkFailedAddressEndpoint implements RestEndpoint {
 	constructor (public readonly address: string) {}
 
-	readonly endpoint = '/routeplanner/free/address';
+	public readonly endpoint = '/routeplanner/free/address';
 
-	readonly method = 'POST';
-	readonly headers = { 'Content-Type': 'application/json' };
-	readonly body = () => ({ address: this.address });
+	public readonly method = 'POST';
+	public readonly headers = { 'Content-Type': 'application/json' };
+	public readonly body = () => ({ address: this.address });
 
-	R = r<void>;
+	public R = r<void>;
 }
 
 export class LavalinkInfoEndpoint implements RestEndpoint {
-	readonly endpoint = '/info';
+	public readonly endpoint = '/info';
 
-	readonly headers = { 'Content-Type': 'application/json' };
+	public readonly headers = { 'Content-Type': 'application/json' };
 
-	R = r<NodeInfo>;
+	public R = r<NodeInfo>;
 }
 
 /**

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -1,7 +1,6 @@
 import { Versions } from '../Constants';
 import type { FilterOptions } from '../guild/Player';
 import type { NodeOption } from '../Shoukaku';
-import { Head } from '../Utils';
 import type { Node, NodeInfo, Stats } from './Node';
 
 export type Severity = 'common' | 'suspicious' | 'fault';
@@ -162,21 +161,10 @@ interface FinalFetchOptions {
 	body?: string;
 }
 
-export interface PluginConfig {
-	serverPlugin: string;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	function: (rest: Rest, ...args: any[]) => unknown;
-}
-
-// https://stackoverflow.com/a/58764959
-type OmitRestArg<F extends PluginConfig['function']> = F extends (rest: Rest, ...args: infer P) => infer R ? (...args: P) => R : never;
-
-export type Plugins = Record<string, PluginConfig>;
-
 /**
  * Wrapper around Lavalink REST API
  */
-export class Rest<TPlugins extends Plugins = {}> {
+export class Rest {
 	/**
 	 * Node that initialized this instance
 	 */
@@ -189,9 +177,6 @@ export class Rest<TPlugins extends Plugins = {}> {
 	 * Credentials to access Lavalink
 	 */
 	protected readonly auth: string;
-
-	protected readonly plugins: TPlugins = {} as TPlugins;
-
 	/**
 	 * @param node An instance of Node
 	 * @param options The options to initialize this rest class
@@ -201,36 +186,10 @@ export class Rest<TPlugins extends Plugins = {}> {
 	 * @param options.secure Weather to use secure protocols or not
 	 * @param options.group Group of this node
 	 */
-	constructor(node: Node, options: NodeOption, plugins?: Plugins) {
+	constructor(node: Node, options: NodeOption) {
 		this.node = node;
 		this.url = `${options.secure ? 'https' : 'http'}://${options.url}/v${Versions.REST_VERSION}`;
 		this.auth = options.auth;
-		(this.plugins as Plugins) = plugins ?? {};
-		return this as Rest<TPlugins & (typeof plugins extends Plugins ? typeof plugins : {})>;
-	}
-
-	static extend(plugins: (PluginConfig & { name: string })[]) {
-		const pluginsObj = Object.fromEntries(plugins?.map(({ name, ...config }) => [ name, { ...config }]));
-		return class extends Rest {
-			constructor(...args: Head<ConstructorParameters<typeof Rest>>) {
-				super(...args, pluginsObj);
-			}
-		};
-	}
-
-	// extend<TName extends string, TPluginConfig extends PluginConfig>(
-	// 	name: TName,
-	// 	pluginConfig: TPluginConfig
-	// ): Rest<TPlugins & Record<TName, TPluginConfig>> {
-	// 	(this.plugins as Plugins)[name] = pluginConfig;
-	// 	return this as unknown as Rest<TPlugins & Record<TName, TPluginConfig>>;
-	// }
-
-	plugin<TPlugin extends keyof TPlugins>(
-		name: TPlugin,
-		...args: Parameters<OmitRestArg<TPlugins[TPlugin]['function']>>
-	): ReturnType<TPlugins[TPlugin]['function']> {
-		return this.plugins[name].function(this, ...args) as ReturnType<TPlugins[TPlugin]['function']>;
 	}
 
 	protected get sessionId(): string {

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -175,6 +175,34 @@ export interface RestMiddleware {
  * Routes should implement this interface to use with fetch function
  * 
  * Properties can be a value, or a function that returns a value to access `this`
+ * 
+ * @example
+ * Example with [LavaSearch](https://github.com/topi314/LavaSearch) `/loadsearch` endpoint
+ * ```
+ *	export class LoadSearchEndpoint implements RestEndpoint {
+ *		constructor(public readonly query: string, public readonly types: string) {}
+ *
+ *		public readonly pluginRequired = {
+ *			name: 'lavasearch-plugin',
+ *			version: '^1.0.0'
+ *		};
+ *
+ *		public readonly endpoint = '/loadsearch';
+ *		public readonly params = () => ({ query: this.query, types: this.types });
+ *
+ *		public readonly R = t<{
+ *			tracks?: Track[];
+ *			albums?: Playlist[];
+ *			artists?: Playlist[];
+ *			playlists?: Playlist[];
+ *			texts?: {
+ *				text: string;
+ *				plugin: Record<string, unknown>;
+ *			};
+ *			plugin: Record<string, unknown>;
+ *		}>;
+ *	}
+ * ```
  */
 export interface RestEndpoint {
 	// TODO: do we even need this? RestError 404/400 would also indicate missing/wrong version of plugin
@@ -187,7 +215,7 @@ export interface RestEndpoint {
 	 */
 	readonly endpoint: FnOrVal<string>;
 	/**
-	 * HTTP request method
+	 * HTTP request method, `GET` by default
 	 */
 	readonly method?: HintedString<'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'>;
 	/**

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -1,6 +1,7 @@
 import { Versions } from '../Constants';
 import type { FilterOptions } from '../guild/Player';
 import type { NodeOption } from '../Shoukaku';
+import { HintedString } from '../Utils';
 import type { Node, NodeInfo, Stats } from './Node';
 
 export type Severity = 'common' | 'suspicious' | 'fault';
@@ -162,6 +163,260 @@ interface FinalFetchOptions {
 }
 
 /**
+ * Inject headers and params globally to a RestClient instance
+ */
+export interface RestMiddleware {
+	readonly headers?: RestEndpoint['headers'];
+	readonly params?: RestEndpoint['params'];
+}
+
+/**
+ * Routes should implement this interface to use with fetch function
+ */
+export interface RestEndpoint {
+	/**
+	 * Lavalink endpoint
+	 */
+	readonly endpoint: string;
+	/**
+	 * HTTP request headers
+	 */
+	readonly headers?: Record<string, string>;
+	/**
+	 * URL params
+	 */
+	readonly params?: Record<string, string>;
+	/**
+	 * HTTP request method
+	 */
+	readonly method?: HintedString<'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'>;
+	/**
+	 * JSON body to send with 
+	 */
+	readonly body?: Record<string, unknown>;
+	/**
+	 * This hack is to work around TypeScript types not existing at runtime.
+	 * We can specify the return type of the endpoint in the fetch function here.
+	 * 
+	 * @example
+	 * This function is never actually called, so the implementation can be simply:
+	 * ```
+	 * R = (response: unknown) => response as LavalinkResponse;
+	 * ```
+	 */
+	R(response: unknown): unknown;
+};
+
+export class NoopMiddleware implements RestMiddleware {}
+
+/**
+ * Exendable generic REST client to make requests to Lavalink
+ */
+export class RestClient<T extends RestMiddleware = NoopMiddleware> {
+	protected readonly middleware: T;
+	protected readonly auth: string;
+	protected readonly userAgent: string;
+	protected readonly baseUrl: string;
+	protected readonly restTimeout: number;
+
+	/**
+	 * @param auth Credentials to access Lavalnk
+	 * @param userAgent User Agent to use when making requests to Lavalink
+	 * @param baseUrl URL of Lavalink
+	 * @param restTimeout Time to wait for a response from the Lavalink REST API before giving up
+	 * @param middleware Inject headers and params globally, see {@link RestMiddleware}
+	 */
+	constructor(
+		auth: string,
+		userAgent: string,
+		baseUrl: string,
+		restTimeout: number,
+		middleware: T = new NoopMiddleware() as T
+	) {
+		this.auth = auth;
+		this.userAgent = userAgent;
+		this.baseUrl = baseUrl;
+		this.restTimeout = restTimeout;
+		this.middleware = middleware;
+		return this as RestClient<typeof middleware>;
+	}
+
+	/**
+	 * Fetch data from endpoint based on config {@link RestEndpoint} and middleware
+	 * @param endpoint Endpoint config (see {@link RestEndpoint})
+	 * @returns Response as specified by endpoint's `R` function
+	 * @throws {@link RestError} from Lavalink error response
+	 * @throws {@link DeserializationError} when parsing response as JSON fails
+	 */
+	async fetch<
+		E extends RestEndpoint,
+		R = ReturnType<E['R']>
+	>(endpoint: E): Promise<R | undefined> {
+		const headers = {
+			'Authorization': this.auth,
+			'User-Agent': this.userAgent,
+			...(this.middleware.headers ?? {}),
+			...(endpoint.headers ?? {})
+		};
+
+		const url = new URL(`${this.baseUrl}${endpoint.endpoint}`);
+
+		const searchParams = {
+			...(this.middleware.params ?? {}),
+			...(endpoint.params ?? {})
+		};
+
+		url.search = new URLSearchParams(searchParams).toString();
+
+		const abortController = new AbortController();
+		const timeout = setTimeout(() => abortController.abort(), this.restTimeout * 1000);
+
+		const method = endpoint.method?.toUpperCase() ?? 'GET';
+
+		const finalFetchOptions: FinalFetchOptions = {
+			method,
+			headers,
+			signal: abortController.signal
+		};
+
+		if (![ 'GET', 'HEAD' ].includes(method) && endpoint.body)
+			finalFetchOptions.body = JSON.stringify(endpoint.body);
+
+		const request = await fetch(url.toString(), finalFetchOptions)
+			.finally(() => clearTimeout(timeout));
+
+		if (!request.ok) {
+			const response = await request
+				.json()
+				.catch(() => null) as LavalinkRestError | null;
+
+			throw new RestError(response ?? {
+				timestamp: Date.now(),
+				status: request.status,
+				error: 'Unknown Error',
+				message: 'Unexpected error response from Lavalink server',
+				path: endpoint.endpoint
+			});
+		}
+
+		try {
+			return await request.json() as R;
+		} catch (e) {
+			// TODO: disscuss if we should ignore this error since the original Rest#fetch ignored it
+			throw new DeserializationError(e);
+		}
+
+	}
+}
+
+export const r = <T>(response: unknown) => response as T;
+
+export class ResolveEndpoint implements RestEndpoint {
+	constructor (public readonly identifier: string) {}
+
+	readonly endpoint = '/loadtracks';
+	readonly params = { identifier: this.identifier };
+
+	R = r<LavalinkResponse>;
+}
+
+export class DecodeEndpoint implements RestEndpoint {
+	constructor (public readonly track: string) {}
+
+	readonly endpoint = '/decodetrack';
+	readonly params = { track: this.track };
+
+	R = r<Track>;
+}
+
+export class GetPlayersEndpoint implements RestEndpoint {
+	constructor (public readonly sessionId: string) {}
+
+	readonly endpoint = `/sessions/${this.sessionId}/players`;
+
+	R = r<LavalinkPlayer[]>;
+}
+
+export class GetPlayerEndpoint implements RestEndpoint {
+	constructor (public readonly sessionId: string, public readonly guildId: string) {}
+
+	readonly endpoint = `/sessions/${this.sessionId}/players/${this.guildId}`;
+
+	R = r<LavalinkPlayer>;
+}
+
+export class UpdatePlayerEndpoint implements RestEndpoint {
+	constructor (public readonly sessionId: string, public readonly data: UpdatePlayerInfo) {}
+
+	readonly endpoint = `/sessions/${this.sessionId}/players/${this.data.guildId}`;
+
+	readonly method = 'PATCH';
+	readonly params = { noReplace: this.data.noReplace?.toString() ?? 'false' };
+	readonly headers = { 'Content-Type': 'application/json' };
+	readonly body = this.data.playerOptions as Record<string, unknown>;
+
+	R = r<LavalinkPlayer>;
+}
+
+export class DestroyPlayerEndpoint implements RestEndpoint {
+	constructor (public readonly sessionId: string, public readonly guildId: string) {}
+
+	readonly endpoint = `/sessions/${this.sessionId}/players/${this.guildId}`;
+
+	readonly method = 'DELETE';
+
+	R = r<void>;
+}
+
+export class UpdateSessionEndpoint implements RestEndpoint {
+	constructor (
+		public readonly sessionId: string,
+		public readonly resuming?: boolean,
+		public readonly timeout?: number
+	) {}
+
+	readonly endpoint = `/sessions/${this.sessionId}`;
+
+	readonly method = 'PATCH';
+	readonly headers = { 'Content-Type': 'application/json' };
+	readonly body = { resuming: this.resuming, timeout: this.timeout };
+
+	R = r<SessionInfo>;
+}
+
+export class StatsEndpoint implements RestEndpoint {
+	readonly endpoint = '/stats';
+
+	R = r<Stats>;
+}
+
+export class RoutePlannerStatusEndpoint implements RestEndpoint {
+	readonly endpoint = '/routeplanner/status';
+
+	R = r<RoutePlanner>;
+}
+
+export class UnmarkFailedAddressEndpoint implements RestEndpoint {
+	constructor (public readonly address: string) {}
+
+	readonly endpoint = '/routeplanner/free/address';
+
+	readonly method = 'POST';
+	readonly headers = { 'Content-Type': 'application/json' };
+	readonly body = { address: this.address };
+
+	R = r<void>;
+}
+
+export class LavalinkInfoEndpoint implements RestEndpoint {
+	readonly endpoint = '/info';
+
+	readonly headers = { 'Content-Type': 'application/json' };
+
+	R = r<NodeInfo>;
+}
+
+/**
  * Wrapper around Lavalink REST API
  */
 export class Rest {
@@ -178,6 +433,10 @@ export class Rest {
 	 */
 	protected readonly auth: string;
 	/**
+	 * Client to make request to Lavalink
+	 */
+	protected readonly client: RestClient;
+	/**
 	 * @param node An instance of Node
 	 * @param options The options to initialize this rest class
 	 * @param options.name Name of this node
@@ -190,6 +449,12 @@ export class Rest {
 		this.node = node;
 		this.url = `${options.secure ? 'https' : 'http'}://${options.url}/v${Versions.REST_VERSION}`;
 		this.auth = options.auth;
+		this.client = new RestClient(
+			this.auth,
+			this.node.manager.options.userAgent,
+			this.url,
+			this.node.manager.options.restTimeout
+		);
 	}
 
 	protected get sessionId(): string {
@@ -202,11 +467,7 @@ export class Rest {
 	 * @returns A promise that resolves to a Lavalink response
 	 */
 	public resolve(identifier: string): Promise<LavalinkResponse | undefined> {
-		const options = {
-			endpoint: '/loadtracks',
-			options: { params: { identifier }}
-		};
-		return this.fetch(options);
+		return this.client.fetch(new ResolveEndpoint(identifier));
 	}
 
 	/**
@@ -215,23 +476,15 @@ export class Rest {
 	 * @returns Promise that resolves to a track
 	 */
 	public decode(track: string): Promise<Track | undefined> {
-		const options = {
-			endpoint: '/decodetrack',
-			options: { params: { track }}
-		};
-		return this.fetch<Track>(options);
+		return this.client.fetch(new DecodeEndpoint(track));
 	}
 
 	/**
 	 * Gets all the player with the specified sessionId
 	 * @returns Promise that resolves to an array of Lavalink players
 	 */
-	public async getPlayers(): Promise<LavalinkPlayer[]> {
-		const options = {
-			endpoint: `/sessions/${this.sessionId}/players`,
-			options: {}
-		};
-		return await this.fetch<LavalinkPlayer[]>(options) ?? [];
+	public async getPlayers(): Promise<LavalinkPlayer[] | undefined> {
+		return this.client.fetch(new GetPlayersEndpoint(this.sessionId));
 	}
 
 	/**
@@ -239,11 +492,7 @@ export class Rest {
 	 * @returns Promise that resolves to a Lavalink player
 	 */
 	public getPlayer(guildId: string): Promise<LavalinkPlayer | undefined> {
-		const options = {
-			endpoint: `/sessions/${this.sessionId}/players/${guildId}`,
-			options: {}
-		};
-		return this.fetch(options);
+		return this.client.fetch(new GetPlayerEndpoint(this.sessionId, guildId));
 	}
 
 	/**
@@ -252,16 +501,7 @@ export class Rest {
 	 * @returns Promise that resolves to a Lavalink player
 	 */
 	public updatePlayer(data: UpdatePlayerInfo): Promise<LavalinkPlayer | undefined> {
-		const options = {
-			endpoint: `/sessions/${this.sessionId}/players/${data.guildId}`,
-			options: {
-				method: 'PATCH',
-				params: { noReplace: data.noReplace?.toString() ?? 'false' },
-				headers: { 'Content-Type': 'application/json' },
-				body: data.playerOptions as Record<string, unknown>
-			}
-		};
-		return this.fetch<LavalinkPlayer>(options);
+		return this.client.fetch(new UpdatePlayerEndpoint(this.sessionId, data));
 	}
 
 	/**
@@ -269,11 +509,7 @@ export class Rest {
 	 * @param guildId guildId where this player is
 	 */
 	public async destroyPlayer(guildId: string): Promise<void> {
-		const options = {
-			endpoint: `/sessions/${this.sessionId}/players/${guildId}`,
-			options: { method: 'DELETE' }
-		};
-		await this.fetch(options);
+		return this.client.fetch(new DestroyPlayerEndpoint(this.sessionId, guildId));
 	}
 
 	/**
@@ -283,15 +519,7 @@ export class Rest {
 	 * @returns Promise that resolves to a Lavalink player
 	 */
 	public updateSession(resuming?: boolean, timeout?: number): Promise<SessionInfo | undefined> {
-		const options = {
-			endpoint: `/sessions/${this.sessionId}`,
-			options: {
-				method: 'PATCH',
-				headers: { 'Content-Type': 'application/json' },
-				body: { resuming, timeout }
-			}
-		};
-		return this.fetch(options);
+		return this.client.fetch(new UpdateSessionEndpoint(this.sessionId, resuming, timeout));
 	}
 
 	/**
@@ -299,11 +527,7 @@ export class Rest {
 	 * @returns Promise that resolves to a node stats response
 	 */
 	public stats(): Promise<Stats | undefined> {
-		const options = {
-			endpoint: '/stats',
-			options: {}
-		};
-		return this.fetch(options);
+		return this.client.fetch(new StatsEndpoint());
 	}
 
 	/**
@@ -311,11 +535,7 @@ export class Rest {
 	 * @returns Promise that resolves to a routeplanner response
 	 */
 	public getRoutePlannerStatus(): Promise<RoutePlanner | undefined> {
-		const options = {
-			endpoint: '/routeplanner/status',
-			options: {}
-		};
-		return this.fetch(options);
+		return this.client.fetch(new RoutePlannerStatusEndpoint());
 	}
 
 	/**
@@ -323,28 +543,14 @@ export class Rest {
 	 * @param address IP address
 	 */
 	public async unmarkFailedAddress(address: string): Promise<void> {
-		const options = {
-			endpoint: '/routeplanner/free/address',
-			options: {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: { address }
-			}
-		};
-		await this.fetch(options);
+		return this.client.fetch(new UnmarkFailedAddressEndpoint(address));
 	}
 
 	/**
 	 * Get Lavalink info
 	 */
 	public getLavalinkInfo(): Promise<NodeInfo | undefined> {
-		const options = {
-			endpoint: '/info',
-			options: {
-				headers: { 'Content-Type': 'application/json' }
-			}
-		};
-		return this.fetch(options);
+		return this.client.fetch(new LavalinkInfoEndpoint());
 	}
 
 	/**
@@ -352,55 +558,20 @@ export class Rest {
 	 * @param fetchOptions.endpoint Lavalink endpoint
 	 * @param fetchOptions.options Options passed to fetch
 	 * @throws `RestError` when encountering a Lavalink error response
+	 * @deprecated Use this.client.fetch() instead, see {@link RestClient#fetch}
 	 * @internal
 	 */
 	protected async fetch<T = unknown>(fetchOptions: FetchOptions) {
-		const { endpoint, options } = fetchOptions;
-		let headers = {
-			'Authorization': this.auth,
-			'User-Agent': this.node.manager.options.userAgent
-		};
+		return this.client.fetch(new class implements RestEndpoint {
+			readonly endpoint = fetchOptions.endpoint;
 
-		if (options.headers) headers = { ...headers, ...options.headers };
+			readonly method = fetchOptions.options.method;
+			readonly headers = fetchOptions.options.headers;
+			readonly params = fetchOptions.options.params;
+			readonly body = fetchOptions.options.body;
 
-		const url = new URL(`${this.url}${endpoint}`);
-
-		if (options.params) url.search = new URLSearchParams(options.params).toString();
-
-		const abortController = new AbortController();
-		const timeout = setTimeout(() => abortController.abort(), this.node.manager.options.restTimeout * 1000);
-
-		const method = options.method?.toUpperCase() ?? 'GET';
-
-		const finalFetchOptions: FinalFetchOptions = {
-			method,
-			headers,
-			signal: abortController.signal
-		};
-
-		if (![ 'GET', 'HEAD' ].includes(method) && options.body)
-			finalFetchOptions.body = JSON.stringify(options.body);
-
-		const request = await fetch(url.toString(), finalFetchOptions)
-			.finally(() => clearTimeout(timeout));
-
-		if (!request.ok) {
-			const response = await request
-				.json()
-				.catch(() => null) as LavalinkRestError | null;
-			throw new RestError(response ?? {
-				timestamp: Date.now(),
-				status: request.status,
-				error: 'Unknown Error',
-				message: 'Unexpected error response from Lavalink server',
-				path: endpoint
-			});
-		}
-		try {
-			return await request.json() as T;
-		} catch {
-			return;
-		}
+			R = r<T>;
+		});
 	}
 }
 
@@ -429,6 +600,14 @@ export class RestError extends Error {
 		this.trace = trace;
 		this.message = message;
 		this.path = path;
+		Object.setPrototypeOf(this, new.target.prototype);
+	}
+}
+
+export class DeserializationError extends Error {
+	constructor(cause: unknown) {
+		super('Failed to deserialize Lavalink response: invalid JSON', { cause });
+		this.name = 'DeserializationError';
 		Object.setPrototypeOf(this, new.target.prototype);
 	}
 }

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -2,7 +2,7 @@ import { Versions } from '../Constants';
 import type { FilterOptions } from '../guild/Player';
 import type { NodeOption } from '../Shoukaku';
 import { fnOrVal, t, validatePluginRequirement } from '../Utils';
-import type { FnOrVal, HintedString, PluginRequirement } from '../Utils';
+import type { FnOrVal, HintedString, PluginRequirement, TField, TReturnType } from '../Utils';
 import type { Node, NodeInfo, NodeInfoPlugin, Stats } from './Node';
 
 export type Severity = 'common' | 'suspicious' | 'fault';
@@ -204,7 +204,7 @@ export interface RestMiddleware {
  *	}
  * ```
  */
-export interface RestEndpoint {
+export interface RestEndpoint extends TField {
 	// TODO: do we even need this? RestError 404/400 would also indicate missing/wrong version of plugin
 	/**
 	 * Plugin required by endpoint
@@ -230,17 +230,6 @@ export interface RestEndpoint {
 	 * JSON body to send with
 	 */
 	readonly body?: FnOrVal<Record<string, unknown> | undefined>;
-	/**
-	 * This hack is to work around TypeScript types not existing at runtime.
-	 * We can specify the return type of the endpoint in the fetch function here.
-	 * 
-	 * @example
-	 * This function is never actually called, so the implementation can be simply:
-	 * ```
-	 * R = (response: unknown) => response as LavalinkResponse;
-	 * ```
-	 */
-	readonly T: (response: unknown) => unknown;
 };
 
 export class NoopMiddleware implements RestMiddleware {}
@@ -292,7 +281,7 @@ export class RestClient<T extends RestMiddleware = NoopMiddleware> {
 	 */
 	public async fetch<
 		E extends RestEndpoint,
-		R = ReturnType<E['T']>
+		R = TReturnType<E>
 	>(endpoint: E): Promise<R | undefined> {
 		const path = fnOrVal(endpoint.endpoint)!;
 

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -221,12 +221,6 @@ export class NoopMiddleware implements RestMiddleware {}
  * Exendable generic REST client to make requests to Lavalink
  */
 export class RestClient<T extends RestMiddleware = NoopMiddleware> {
-	protected readonly middleware: T;
-	protected readonly auth: string;
-	protected readonly userAgent: string;
-	protected readonly baseUrl: string;
-	protected readonly restTimeout: number;
-
 	/**
 	 * @param auth Credentials to access Lavalnk
 	 * @param userAgent User Agent to use when making requests to Lavalink
@@ -235,17 +229,12 @@ export class RestClient<T extends RestMiddleware = NoopMiddleware> {
 	 * @param middleware Inject headers and params globally, see {@link RestMiddleware}
 	 */
 	constructor(
-		auth: string,
-		userAgent: string,
-		baseUrl: string,
-		restTimeout: number,
-		middleware: T = new NoopMiddleware() as T
+		protected readonly auth: string,
+		protected readonly userAgent: string,
+		protected readonly baseUrl: string,
+		protected readonly restTimeout: number,
+		protected readonly middleware: T = new NoopMiddleware() as T
 	) {
-		this.auth = auth;
-		this.userAgent = userAgent;
-		this.baseUrl = baseUrl;
-		this.restTimeout = restTimeout;
-		this.middleware = middleware;
 		return this as RestClient<typeof middleware>;
 	}
 

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -1,7 +1,7 @@
 import { Versions } from '../Constants';
 import type { FilterOptions } from '../guild/Player';
 import type { NodeOption } from '../Shoukaku';
-import { validatePluginRequirement } from '../Utils';
+import { t, validatePluginRequirement } from '../Utils';
 import type { HintedString, PluginRequirement } from '../Utils';
 import type { Node, NodeInfo, NodeInfoPlugin, Stats } from './Node';
 
@@ -331,15 +331,13 @@ export class RestClient<T extends RestMiddleware = NoopMiddleware> {
 	}
 }
 
-export const r = <T>(response: unknown) => response as T;
-
 export class ResolveEndpoint implements RestEndpoint {
 	constructor (public readonly identifier: string) {}
 
 	public readonly endpoint = '/loadtracks';
 	public readonly params = () => ({ identifier: this.identifier });
 
-	public R = r<LavalinkResponse>;
+	public R = t<LavalinkResponse>;
 }
 
 export class DecodeEndpoint implements RestEndpoint {
@@ -348,7 +346,7 @@ export class DecodeEndpoint implements RestEndpoint {
 	public readonly endpoint = '/decodetrack';
 	public readonly params = () => ({ track: this.track });
 
-	public R = r<Track>;
+	public R = t<Track>;
 }
 
 export class GetPlayersEndpoint implements RestEndpoint {
@@ -356,7 +354,7 @@ export class GetPlayersEndpoint implements RestEndpoint {
 
 	public readonly endpoint = () => `/sessions/${this.sessionId}/players`;
 
-	public R = r<LavalinkPlayer[]>;
+	public R = t<LavalinkPlayer[]>;
 }
 
 export class GetPlayerEndpoint implements RestEndpoint {
@@ -364,7 +362,7 @@ export class GetPlayerEndpoint implements RestEndpoint {
 
 	public readonly endpoint = () => `/sessions/${this.sessionId}/players/${this.guildId}`;
 
-	public R = r<LavalinkPlayer>;
+	public R = t<LavalinkPlayer>;
 }
 
 export class UpdatePlayerEndpoint implements RestEndpoint {
@@ -377,7 +375,7 @@ export class UpdatePlayerEndpoint implements RestEndpoint {
 	public readonly headers = { 'Content-Type': 'application/json' };
 	public readonly body = () => this.data.playerOptions as Record<string, unknown>;
 
-	public R = r<LavalinkPlayer>;
+	public R = t<LavalinkPlayer>;
 }
 
 export class DestroyPlayerEndpoint implements RestEndpoint {
@@ -387,7 +385,7 @@ export class DestroyPlayerEndpoint implements RestEndpoint {
 
 	public readonly method = 'DELETE';
 
-	public R = r<void>;
+	public R = t<void>;
 }
 
 export class UpdateSessionEndpoint implements RestEndpoint {
@@ -403,19 +401,19 @@ export class UpdateSessionEndpoint implements RestEndpoint {
 	public readonly headers = { 'Content-Type': 'application/json' };
 	public readonly body = () => ({ resuming: this.resuming, timeout: this.timeout });
 
-	public R = r<SessionInfo>;
+	public R = t<SessionInfo>;
 }
 
 export class StatsEndpoint implements RestEndpoint {
 	public readonly endpoint = '/stats';
 
-	public R = r<Stats>;
+	public R = t<Stats>;
 }
 
 export class RoutePlannerStatusEndpoint implements RestEndpoint {
 	public readonly endpoint = '/routeplanner/status';
 
-	public R = r<RoutePlanner>;
+	public R = t<RoutePlanner>;
 }
 
 export class UnmarkFailedAddressEndpoint implements RestEndpoint {
@@ -427,7 +425,7 @@ export class UnmarkFailedAddressEndpoint implements RestEndpoint {
 	public readonly headers = { 'Content-Type': 'application/json' };
 	public readonly body = () => ({ address: this.address });
 
-	public R = r<void>;
+	public R = t<void>;
 }
 
 export class LavalinkInfoEndpoint implements RestEndpoint {
@@ -435,7 +433,7 @@ export class LavalinkInfoEndpoint implements RestEndpoint {
 
 	public readonly headers = { 'Content-Type': 'application/json' };
 
-	public R = r<NodeInfo>;
+	public R = t<NodeInfo>;
 }
 
 /**
@@ -592,7 +590,7 @@ export class Rest {
 			readonly params = fetchOptions.options.params;
 			readonly body = fetchOptions.options.body;
 
-			R = r<T>;
+			R = t<T>;
 		});
 	}
 }

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -190,7 +190,7 @@ export interface RestMiddleware {
  *		public readonly endpoint = '/loadsearch';
  *		public readonly params = () => ({ query: this.query, types: this.types });
  *
- *		public readonly R = t<{
+ *		public readonly T = t<{
  *			tracks?: Track[];
  *			albums?: Playlist[];
  *			artists?: Playlist[];
@@ -240,7 +240,7 @@ export interface RestEndpoint {
 	 * R = (response: unknown) => response as LavalinkResponse;
 	 * ```
 	 */
-	readonly R: (response: unknown) => unknown;
+	readonly T: (response: unknown) => unknown;
 };
 
 export class NoopMiddleware implements RestMiddleware {}
@@ -292,7 +292,7 @@ export class RestClient<T extends RestMiddleware = NoopMiddleware> {
 	 */
 	public async fetch<
 		E extends RestEndpoint,
-		R = ReturnType<E['R']>
+		R = ReturnType<E['T']>
 	>(endpoint: E): Promise<R | undefined> {
 		const path = fnOrVal(endpoint.endpoint)!;
 
@@ -364,7 +364,7 @@ export class ResolveEndpoint implements RestEndpoint {
 	public readonly endpoint = '/loadtracks';
 	public readonly params = () => ({ identifier: this.identifier });
 
-	public readonly R = t<LavalinkResponse>;
+	public readonly T = t<LavalinkResponse>;
 }
 
 export class DecodeEndpoint implements RestEndpoint {
@@ -373,7 +373,7 @@ export class DecodeEndpoint implements RestEndpoint {
 	public readonly endpoint = '/decodetrack';
 	public readonly params = () => ({ track: this.track });
 
-	public readonly R = t<Track>;
+	public readonly T = t<Track>;
 }
 
 export class GetPlayersEndpoint implements RestEndpoint {
@@ -381,7 +381,7 @@ export class GetPlayersEndpoint implements RestEndpoint {
 
 	public readonly endpoint = () => `/sessions/${this.sessionId}/players`;
 
-	public readonly R = t<LavalinkPlayer[]>;
+	public readonly T = t<LavalinkPlayer[]>;
 }
 
 export class GetPlayerEndpoint implements RestEndpoint {
@@ -389,7 +389,7 @@ export class GetPlayerEndpoint implements RestEndpoint {
 
 	public readonly endpoint = () => `/sessions/${this.sessionId}/players/${this.guildId}`;
 
-	public readonly R = t<LavalinkPlayer>;
+	public readonly T = t<LavalinkPlayer>;
 }
 
 export class UpdatePlayerEndpoint implements RestEndpoint {
@@ -402,7 +402,7 @@ export class UpdatePlayerEndpoint implements RestEndpoint {
 	public readonly headers = { 'Content-Type': 'application/json' };
 	public readonly body = () => this.data.playerOptions as Record<string, unknown>;
 
-	public readonly R = t<LavalinkPlayer>;
+	public readonly T = t<LavalinkPlayer>;
 }
 
 export class DestroyPlayerEndpoint implements RestEndpoint {
@@ -412,7 +412,7 @@ export class DestroyPlayerEndpoint implements RestEndpoint {
 
 	public readonly method = 'DELETE';
 
-	public readonly R = t<void>;
+	public readonly T = t<void>;
 }
 
 export class UpdateSessionEndpoint implements RestEndpoint {
@@ -428,19 +428,19 @@ export class UpdateSessionEndpoint implements RestEndpoint {
 	public readonly headers = { 'Content-Type': 'application/json' };
 	public readonly body = () => ({ resuming: this.resuming, timeout: this.timeout });
 
-	public readonly R = t<SessionInfo>;
+	public readonly T = t<SessionInfo>;
 }
 
 export class StatsEndpoint implements RestEndpoint {
 	public readonly endpoint = '/stats';
 
-	public readonly R = t<Stats>;
+	public readonly T = t<Stats>;
 }
 
 export class RoutePlannerStatusEndpoint implements RestEndpoint {
 	public readonly endpoint = '/routeplanner/status';
 
-	public readonly R = t<RoutePlanner>;
+	public readonly T = t<RoutePlanner>;
 }
 
 export class UnmarkFailedAddressEndpoint implements RestEndpoint {
@@ -452,7 +452,7 @@ export class UnmarkFailedAddressEndpoint implements RestEndpoint {
 	public readonly headers = { 'Content-Type': 'application/json' };
 	public readonly body = () => ({ address: this.address });
 
-	public readonly R = t<void>;
+	public readonly T = t<void>;
 }
 
 export class LavalinkInfoEndpoint implements RestEndpoint {
@@ -460,7 +460,7 @@ export class LavalinkInfoEndpoint implements RestEndpoint {
 
 	public readonly headers = { 'Content-Type': 'application/json' };
 
-	public readonly R = t<NodeInfo>;
+	public readonly T = t<NodeInfo>;
 }
 
 /**
@@ -617,7 +617,7 @@ export class Rest {
 			public readonly params = fetchOptions.options.params;
 			public readonly body = fetchOptions.options.body;
 
-			public readonly R = t<T>;
+			public readonly T = t<T>;
 		});
 	}
 }

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -162,6 +162,12 @@ interface FinalFetchOptions {
 	body?: string;
 }
 
+type FnOrVal<T> = T | (() => T);
+
+function fnOrVal<T>(input?: T | (() => T)): T | undefined {
+	return typeof input === 'function' ? (input as () => T)?.() : input;
+}
+
 /**
  * Inject headers and params globally to a RestClient instance
  */
@@ -172,28 +178,30 @@ export interface RestMiddleware {
 
 /**
  * Routes should implement this interface to use with fetch function
+ * 
+ * Properties can be a value, or a function that returns a value to access `this`
  */
 export interface RestEndpoint {
 	/**
 	 * Lavalink endpoint
 	 */
-	readonly endpoint: string;
-	/**
-	 * HTTP request headers
-	 */
-	readonly headers?: Record<string, string>;
-	/**
-	 * URL params
-	 */
-	readonly params?: Record<string, string>;
+	readonly endpoint: FnOrVal<string>;
 	/**
 	 * HTTP request method
 	 */
 	readonly method?: HintedString<'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'>;
 	/**
-	 * JSON body to send with 
+	 * HTTP request headers
 	 */
-	readonly body?: Record<string, unknown>;
+	readonly headers?: FnOrVal<Record<string, string>>;
+	/**
+	 * URL params
+	 */
+	readonly params?: FnOrVal<Record<string, string>>;
+	/**
+	 * JSON body to send with
+	 */
+	readonly body?: FnOrVal<Record<string, unknown>>;
 	/**
 	 * This hack is to work around TypeScript types not existing at runtime.
 	 * We can specify the return type of the endpoint in the fetch function here.
@@ -255,15 +263,17 @@ export class RestClient<T extends RestMiddleware = NoopMiddleware> {
 		const headers = {
 			'Authorization': this.auth,
 			'User-Agent': this.userAgent,
-			...(this.middleware.headers ?? {}),
-			...(endpoint.headers ?? {})
+			...(fnOrVal(this.middleware.headers) ?? {}),
+			...(fnOrVal(endpoint.headers) ?? {})
 		};
 
-		const url = new URL(`${this.baseUrl}${endpoint.endpoint}`);
+		const path = fnOrVal(endpoint.endpoint)!;
+
+		const url = new URL(`${this.baseUrl}${path}`);
 
 		const searchParams = {
-			...(this.middleware.params ?? {}),
-			...(endpoint.params ?? {})
+			...(fnOrVal(this.middleware.params) ?? {}),
+			...(fnOrVal(endpoint.params) ?? {})
 		};
 
 		url.search = new URLSearchParams(searchParams).toString();
@@ -279,8 +289,10 @@ export class RestClient<T extends RestMiddleware = NoopMiddleware> {
 			signal: abortController.signal
 		};
 
-		if (![ 'GET', 'HEAD' ].includes(method) && endpoint.body)
-			finalFetchOptions.body = JSON.stringify(endpoint.body);
+		const body = fnOrVal(endpoint.body);
+
+		if (![ 'GET', 'HEAD' ].includes(method) && body)
+			finalFetchOptions.body = JSON.stringify(body);
 
 		const request = await fetch(url.toString(), finalFetchOptions)
 			.finally(() => clearTimeout(timeout));
@@ -295,7 +307,7 @@ export class RestClient<T extends RestMiddleware = NoopMiddleware> {
 				status: request.status,
 				error: 'Unknown Error',
 				message: 'Unexpected error response from Lavalink server',
-				path: endpoint.endpoint
+				path: path
 			});
 		}
 
@@ -315,7 +327,7 @@ export class ResolveEndpoint implements RestEndpoint {
 	constructor (public readonly identifier: string) {}
 
 	readonly endpoint = '/loadtracks';
-	readonly params = { identifier: this.identifier };
+	readonly params = () => ({ identifier: this.identifier });
 
 	R = r<LavalinkResponse>;
 }
@@ -324,7 +336,7 @@ export class DecodeEndpoint implements RestEndpoint {
 	constructor (public readonly track: string) {}
 
 	readonly endpoint = '/decodetrack';
-	readonly params = { track: this.track };
+	readonly params = () => ({ track: this.track });
 
 	R = r<Track>;
 }
@@ -332,7 +344,7 @@ export class DecodeEndpoint implements RestEndpoint {
 export class GetPlayersEndpoint implements RestEndpoint {
 	constructor (public readonly sessionId: string) {}
 
-	readonly endpoint = `/sessions/${this.sessionId}/players`;
+	readonly endpoint = () => `/sessions/${this.sessionId}/players`;
 
 	R = r<LavalinkPlayer[]>;
 }
@@ -340,7 +352,7 @@ export class GetPlayersEndpoint implements RestEndpoint {
 export class GetPlayerEndpoint implements RestEndpoint {
 	constructor (public readonly sessionId: string, public readonly guildId: string) {}
 
-	readonly endpoint = `/sessions/${this.sessionId}/players/${this.guildId}`;
+	readonly endpoint = () => `/sessions/${this.sessionId}/players/${this.guildId}`;
 
 	R = r<LavalinkPlayer>;
 }
@@ -348,12 +360,12 @@ export class GetPlayerEndpoint implements RestEndpoint {
 export class UpdatePlayerEndpoint implements RestEndpoint {
 	constructor (public readonly sessionId: string, public readonly data: UpdatePlayerInfo) {}
 
-	readonly endpoint = `/sessions/${this.sessionId}/players/${this.data.guildId}`;
+	readonly endpoint = () => `/sessions/${this.sessionId}/players/${this.data.guildId}`;
 
 	readonly method = 'PATCH';
-	readonly params = { noReplace: this.data.noReplace?.toString() ?? 'false' };
+	readonly params = () => ({ noReplace: this.data.noReplace?.toString() ?? 'false' });
 	readonly headers = { 'Content-Type': 'application/json' };
-	readonly body = this.data.playerOptions as Record<string, unknown>;
+	readonly body = () => this.data.playerOptions as Record<string, unknown>;
 
 	R = r<LavalinkPlayer>;
 }
@@ -361,7 +373,7 @@ export class UpdatePlayerEndpoint implements RestEndpoint {
 export class DestroyPlayerEndpoint implements RestEndpoint {
 	constructor (public readonly sessionId: string, public readonly guildId: string) {}
 
-	readonly endpoint = `/sessions/${this.sessionId}/players/${this.guildId}`;
+	readonly endpoint = () => `/sessions/${this.sessionId}/players/${this.guildId}`;
 
 	readonly method = 'DELETE';
 
@@ -375,11 +387,11 @@ export class UpdateSessionEndpoint implements RestEndpoint {
 		public readonly timeout?: number
 	) {}
 
-	readonly endpoint = `/sessions/${this.sessionId}`;
+	readonly endpoint = () => `/sessions/${this.sessionId}`;
 
 	readonly method = 'PATCH';
 	readonly headers = { 'Content-Type': 'application/json' };
-	readonly body = { resuming: this.resuming, timeout: this.timeout };
+	readonly body = () => ({ resuming: this.resuming, timeout: this.timeout });
 
 	R = r<SessionInfo>;
 }
@@ -403,7 +415,7 @@ export class UnmarkFailedAddressEndpoint implements RestEndpoint {
 
 	readonly method = 'POST';
 	readonly headers = { 'Content-Type': 'application/json' };
-	readonly body = { address: this.address };
+	readonly body = () => ({ address: this.address });
 
 	R = r<void>;
 }

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -227,12 +227,13 @@ export class NoopMiddleware implements RestMiddleware {}
  * Exendable generic REST client to make requests to Lavalink
  */
 export class RestClient<T extends RestMiddleware = NoopMiddleware> {
+	protected _nodePlugins?: NodeInfoPlugin[];
+
 	/**
 	 * @param auth Credentials to access Lavalnk
 	 * @param userAgent User Agent to use when making requests to Lavalink
 	 * @param baseUrl URL of Lavalink
 	 * @param restTimeout Time to wait for a response from the Lavalink REST API before giving up
-	 * @param nodePlugins Plugins enabled on Lavalink node
 	 * @param middleware Inject headers and params globally, see {@link RestMiddleware}
 	 */
 	constructor(
@@ -240,10 +241,18 @@ export class RestClient<T extends RestMiddleware = NoopMiddleware> {
 		protected readonly userAgent: string,
 		protected readonly baseUrl: string,
 		protected readonly restTimeout: number,
-		protected readonly nodePlugins?: NodeInfoPlugin[],
 		protected readonly middleware: T = new NoopMiddleware() as T
 	) {
 		return this as RestClient<typeof middleware>;
+	}
+
+	private async getNodePlugins() {
+		if (!this._nodePlugins) {
+			const info = await this.fetch(new LavalinkInfoEndpoint());
+			this._nodePlugins = info?.plugins ?? [];
+		}
+
+		return this._nodePlugins;
 	}
 
 	/**
@@ -262,7 +271,7 @@ export class RestClient<T extends RestMiddleware = NoopMiddleware> {
 
 		// TODO: should we cache the plugin check somehow?
 		if (endpoint.pluginRequired)
-			validatePluginRequirement(`endpoint ${path}`, endpoint.pluginRequired, this.nodePlugins);
+			validatePluginRequirement(`endpoint ${path}`, endpoint.pluginRequired, await this.getNodePlugins());
 
 		const headers = {
 			'Authorization': this.auth,

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -583,14 +583,14 @@ export class Rest {
 	 */
 	protected async fetch<T = unknown>(fetchOptions: FetchOptions) {
 		return this.client.fetch(new class implements RestEndpoint {
-			readonly endpoint = fetchOptions.endpoint;
+			public readonly endpoint = fetchOptions.endpoint;
 
-			readonly method = fetchOptions.options.method;
-			readonly headers = fetchOptions.options.headers;
-			readonly params = fetchOptions.options.params;
-			readonly body = fetchOptions.options.body;
+			public readonly method = fetchOptions.options.method;
+			public readonly headers = fetchOptions.options.headers;
+			public readonly params = fetchOptions.options.params;
+			public readonly body = fetchOptions.options.body;
 
-			R = t<T>;
+			public R = t<T>;
 		});
 	}
 }

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -205,7 +205,6 @@ export interface RestMiddleware {
  * ```
  */
 export interface RestEndpoint extends TField {
-	// TODO: do we even need this? RestError 404/400 would also indicate missing/wrong version of plugin
 	/**
 	 * Plugin required by endpoint
 	 */
@@ -238,13 +237,12 @@ export class NoopMiddleware implements RestMiddleware {}
  * Exendable generic REST client to make requests to Lavalink
  */
 export class RestClient<T extends RestMiddleware = NoopMiddleware> {
-	protected nodePlugins?: NodeInfoPlugin[];
-
 	/**
 	 * @param auth Credentials to access Lavalnk
 	 * @param userAgent User Agent to use when making requests to Lavalink
 	 * @param baseUrl URL of Lavalink
 	 * @param restTimeout Time to wait for a response from the Lavalink REST API before giving up
+	 * @param nodePlugins Plugins available on this node
 	 * @param middleware Inject headers and params globally, see {@link RestMiddleware}
 	 */
 	constructor(
@@ -252,6 +250,7 @@ export class RestClient<T extends RestMiddleware = NoopMiddleware> {
 		protected readonly userAgent: string,
 		protected readonly baseUrl: string,
 		protected readonly restTimeout: number,
+		protected nodePlugins: NodeInfoPlugin[] | null = null,
 		protected readonly middleware: T = new NoopMiddleware() as T
 	) {
 		return this as RestClient<typeof middleware>;
@@ -489,7 +488,9 @@ export class Rest {
 			this.auth,
 			this.node.manager.options.userAgent,
 			this.url,
-			this.node.manager.options.restTimeout
+			this.node.manager.options.restTimeout,
+			// TODO: figure out if this is ever populated since Node#info is never reassigned from null
+			this.node.info?.plugins
 		);
 	}
 

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -1,8 +1,9 @@
 import { Versions } from '../Constants';
 import type { FilterOptions } from '../guild/Player';
 import type { NodeOption } from '../Shoukaku';
-import { HintedString } from '../Utils';
-import type { Node, NodeInfo, Stats } from './Node';
+import { validatePluginRequirement } from '../Utils';
+import type { HintedString, PluginRequirement } from '../Utils';
+import type { Node, NodeInfo, NodeInfoPlugin, Stats } from './Node';
 
 export type Severity = 'common' | 'suspicious' | 'fault';
 
@@ -182,6 +183,11 @@ export interface RestMiddleware {
  * Properties can be a value, or a function that returns a value to access `this`
  */
 export interface RestEndpoint {
+	// TODO: do we even need this? RestError 404/400 would also indicate missing/wrong version of plugin
+	/**
+	 * Plugin required by endpoint
+	 */
+	readonly pluginRequired?: PluginRequirement;
 	/**
 	 * Lavalink endpoint
 	 */
@@ -226,6 +232,7 @@ export class RestClient<T extends RestMiddleware = NoopMiddleware> {
 	 * @param userAgent User Agent to use when making requests to Lavalink
 	 * @param baseUrl URL of Lavalink
 	 * @param restTimeout Time to wait for a response from the Lavalink REST API before giving up
+	 * @param nodePlugins Plugins enabled on Lavalink node
 	 * @param middleware Inject headers and params globally, see {@link RestMiddleware}
 	 */
 	constructor(
@@ -233,6 +240,7 @@ export class RestClient<T extends RestMiddleware = NoopMiddleware> {
 		protected readonly userAgent: string,
 		protected readonly baseUrl: string,
 		protected readonly restTimeout: number,
+		protected readonly nodePlugins?: NodeInfoPlugin[],
 		protected readonly middleware: T = new NoopMiddleware() as T
 	) {
 		return this as RestClient<typeof middleware>;
@@ -244,19 +252,24 @@ export class RestClient<T extends RestMiddleware = NoopMiddleware> {
 	 * @returns Response as specified by endpoint's `R` function
 	 * @throws {@link RestError} from Lavalink error response
 	 * @throws {@link DeserializationError} when parsing response as JSON fails
+	 * @throws {@link PluginError} when plugin required by endpoint is not satisfied by plugins on this node
 	 */
 	async fetch<
 		E extends RestEndpoint,
 		R = ReturnType<E['R']>
 	>(endpoint: E): Promise<R | undefined> {
+		const path = fnOrVal(endpoint.endpoint)!;
+
+		// TODO: should we cache the plugin check somehow?
+		if (endpoint.pluginRequired)
+			validatePluginRequirement(`endpoint ${path}`, endpoint.pluginRequired, this.nodePlugins);
+
 		const headers = {
 			'Authorization': this.auth,
 			'User-Agent': this.userAgent,
 			...(fnOrVal(this.middleware.headers) ?? {}),
 			...(fnOrVal(endpoint.headers) ?? {})
 		};
-
-		const path = fnOrVal(endpoint.endpoint)!;
 
 		const url = new URL(`${this.baseUrl}${path}`);
 

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -303,7 +303,6 @@ export class RestClient<T extends RestMiddleware = NoopMiddleware> {
 		try {
 			return await request.json() as R;
 		} catch (e) {
-			// TODO: disscuss if we should ignore this error since the original Rest#fetch ignored it
 			throw new DeserializationError(e);
 		}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "node16",
     "moduleResolution": "node16",
     "outDir": "dist",
-    "target": "es2020",
+    "target": "es2022",
     "declaration": true,
     "declarationMap": true, 
     "sourceMap": true,


### PR DESCRIPTION
Implements REST and WebSocket client plugins, addresses #185.

Design decisions are also tracked here.

Not in scope
- custom sources

REST
- [x] routes
- [x] plugin filters ([docs](https://lavalink.dev/api/rest.html#plugin-filters))
- [ ] plugin info ([docs](https://lavalink.dev/api/rest.html#track))

WebSocket
- [x] events

Misc
- [x] plugin version check
- [x] documentation
- [ ] clear todos
- [ ] testing